### PR TITLE
Add seed as command line argument

### DIFF
--- a/grammarinator/generate.py
+++ b/grammarinator/generate.py
@@ -266,8 +266,13 @@ def execute():
                         help='number of tests to generate (default: %(default)s).')
     parser.add_argument('--sys-recursion-limit', metavar='NUM', type=int, default=sys.getrecursionlimit(),
                         help='override maximum depth of the Python interpreter stack')
+    parser.add_argument('--random-seed', type=int, metavar='NUM',
+                        help='initialize random number generator with fixed seed (not set by default; noneffective if parallelization is enabled).')
     parser.add_argument('--version', action='version', version='%(prog)s {version}'.format(version=__version__))
     args = parser.parse_args()
+
+    if args.jobs == 1 and args.random_seed:
+        random.seed(args.random_seed)
 
     logger.setLevel(args.log_level)
     sys.setrecursionlimit(args.sys_recursion_limit)


### PR DESCRIPTION
Add seed as command line argument to make generating repeatable (it is need to be applied combined with "-j 1" argument, because it needs to run as a single process), if seed is not given by the user, the generating is still random for every generating.

Signed-off-by: matedabis mdabis@inf.u-szeged.hu