### PR TITLE
Improved charset handling

### DIFF
--- a/tests/grammars/Charset.g4
+++ b/tests/grammars/Charset.g4
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020 Renata Hodovan, Akos Kiss.
+ * Copyright (c) 2020 Sebastian Kimberk.
+ *
+ * Licensed under the BSD 3-Clause License
+ * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+ * This file may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+
+/*
+ * Tests handling of charsets (especially with escaped characters).
+ */
+
+// TEST-PROCESS: {grammar}.g4 -o {tmpdir}
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -o {tmpdir}/{grammar}%d.txt
+// TEST-ANTLR: {grammar}.g4 -o {tmpdir}
+// TEST-PARSE: -p {grammar}Parser -l {grammar}Lexer -r start {tmpdir}/{grammar}%d.txt
+
+grammar Charset;
+
+start
+  : SPECIAL_ESCAPE NON_RANGE_DASH UNICODE_ESCAPE RANGE
+  ;
+
+SPECIAL_ESCAPE
+  : [\-\]] [\]] [\-] [a\-] [\]a] [+\-]
+  ;
+
+NON_RANGE_DASH
+  : [-a] [a-] [-] [--] [-\-] [-\--]
+  ;
+
+UNICODE_ESCAPE
+  : [a\u1f01\u{1f01}b\u{0}\u{000000}]
+  ;
+
+RANGE
+  : [a-zA-Z0-9] ["\\\u0000-\u001F] [a\u{100}-\u0f00] [---] [\--\-]
+  ;


### PR DESCRIPTION
I was generating a fuzzer for the JSON grammar from `antlr/grammars-v4` and noticed some differences between how ANTLR and grammarinator handle charsets.

The specific cases I noticed:

`["\\\u0000-\u001F]` represents the characters `"` and `\` and the range `\u0000-\u001F`. However, `re.split(r'(\w-\w)', src)` doesn't split as intended so grammarinator parses this as five characters.

`[+\-]` represents two characters (`+` and `-`) in ANTLR, with `-` being escaped. However, this escape isn't handled by `.decode('unicode_escape')`, so grammarinator parses it as `+`, `\`, and `-`.

I ported a simplified version of ANTLR's charset parsing code to Python to replace the current handling. It handles the above cases correctly, as well as adds the ability to specify unicode using the `\u{123}` syntax, which would fix https://github.com/renatahodovan/grammarinator/issues/15.

The new code is considerably more complex than the previous code, so I put it in a new file. I'm not sure if this is within the scope of changes you think are useful, or if it should be implemented some other way, but I figured I'd make the PR and see what you think.