### PR TITLE
Fix lint issues

### DIFF
--- a/grammarinator/process.py
+++ b/grammarinator/process.py
@@ -318,8 +318,8 @@ def build_graph(antlr_parser_cls, actions, lexer_root, parser_root):
 
             try:
                 codepoint = int(s[hex_start_offset:hex_end_offset], 16)
-            except ValueError:
-                raise ValueError('Invalid hex value')
+            except ValueError as exc:
+                raise ValueError('Invalid hex value') from exc
 
             if codepoint < 0 or codepoint > maxunicode:
                 raise ValueError('Invalid unicode codepoint')

--- a/grammarinator/runtime/tree.py
+++ b/grammarinator/runtime/tree.py
@@ -172,4 +172,4 @@ class UnlexerRule(BaseRule):
         self.src = src
 
     def __str__(self):
-        return self.src or super(UnlexerRule, self).__str__()
+        return self.src or super().__str__()


### PR DESCRIPTION
- Re-raising exceptions using the `from` keyword.
- Using Python 3 style `super()` without arguments.