### PR TITLE
ANTLR's NOT for chars

### DIFF
--- a/grammarinator/process.py
+++ b/grammarinator/process.py
@@ -378,7 +378,12 @@ def build_graph(actions, lexer_root, parser_root):
 
         if node.STRING_LITERAL():
             assert len(str(node.STRING_LITERAL())) > 2, 'Negated string literal must not be empty.'
-            first_char = ord(str(node.STRING_LITERAL())[1])
+            # unescape '
+            c = node.STRING_LITERAL().symbol.text[1:-1].replace("\\'", "'")
+            # decode unicode
+            decode = c.encode()
+            decode = decode.decode("unicode-escape", "strict")
+            first_char = ord(str(decode))
             return [(first_char, first_char + 1)]
 
         if node.TOKEN_REF():

--- a/grammarinator/process.py
+++ b/grammarinator/process.py
@@ -378,12 +378,11 @@ def build_graph(actions, lexer_root, parser_root):
 
         if node.STRING_LITERAL():
             assert len(str(node.STRING_LITERAL())) > 2, 'Negated string literal must not be empty.'
-            # unescape '
-            c = node.STRING_LITERAL().symbol.text[1:-1].replace("\\'", "'")
-            # decode unicode
-            decode = c.encode()
-            decode = decode.decode("unicode-escape", "strict")
-            first_char = ord(str(decode))
+            s = node.STRING_LITERAL().symbol.text[1:-1]
+            # handle escaped stuff and unicodes
+            encoded = s.encode()
+            decoded = encoded.decode("unicode-escape", "strict")
+            first_char = ord(str(decoded[0]))
             return [(first_char, first_char + 1)]
 
         if node.TOKEN_REF():


### PR DESCRIPTION
Changed the following two things using the NOT feature in ANTLR:
- Unescape ' because in ANTLR it has to be escaped (e.g. `Comment: ~'\'';`) This is done with the `.replace("\'", "'")`
  Without these patch, the code will use the second char which is then the backslash instead of the quote character.
- Added Unicode support. This is done by the `decode("unicode-escape", "strict")`.
  Without these patch, the use of any Unicode will also lead to backslash.


Note: Using NOT for a string is still bugged. Only the first char of a string is used and not the whole string. But this would be a bigger change in higher parts.