### PR TITLE
Drop support of Python3.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
     runs-on: ${{ matrix.os }}
     steps:
       - run: git config --global core.autocrlf input

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ The `trophy page`_ of the found issues is available from the wiki.
 Requirements
 ============
 
-* Python_ >= 3.5
+* Python_ >= 3.6
 * Java_ SE >= 7 JRE or JDK (the latter is optional)
 
 .. _Python: https://www.python.org

--- a/grammarinator/generate.py
+++ b/grammarinator/generate.py
@@ -129,7 +129,7 @@ class Generator(object):
             tree_basename = basename(self.out_format)
             if '%d' not in tree_basename:
                 base, ext = splitext(tree_basename)
-                tree_basename = '{base}%d{ext}'.format(base=base, ext=ext)
+                tree_basename = f'{base}%d{ext}'
             tree_fn = join(self.population.directory, tree_basename % index + Tree.extension)
             self.population.add_tree(tree_fn)
             tree.save(tree_fn)
@@ -154,7 +154,7 @@ class Generator(object):
         if not hasattr(start_rule, 'min_depth'):
             logger.warning('The \'min_depth\' property of %s is not set. Fallback to 0.', rule)
         elif start_rule.min_depth > max_depth:
-            raise ValueError('{rule} cannot be generated within the given depth: {max_depth} (min needed: {depth}).'.format(rule=rule, max_depth=max_depth, depth=start_rule.min_depth))
+            raise ValueError(f'{rule} cannot be generated within the given depth: {max_depth} (min needed: {start_rule.min_depth}).')
 
         instances = {}
 
@@ -221,7 +221,7 @@ def execute():
     def restricted_float(value):
         value = float(value)
         if value <= 0.0 or value > 1.0:
-            raise ArgumentTypeError('{value!r} not in range (0.0, 1.0]'.format(value=value))
+            raise ArgumentTypeError(f'{value!r} not in range (0.0, 1.0]')
         return value
 
     parser = ArgumentParser(description='Grammarinator: Generate', epilog="""

--- a/grammarinator/parse.py
+++ b/grammarinator/parse.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2018-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -76,18 +76,16 @@ class ParserFactory(object):
             # Check if the rule is a labeled alternative.
             if not class_name.lower().startswith(rule_name.lower()):
                 alt_name = class_name[:-len('Context')] if class_name.endswith('Context') else class_name
-                rule_name = '{rule_name}_{alternative}'.format(
-                    rule_name=rule_name,
-                    alternative=alt_name[0].upper() + alt_name[1:])
+                rule_name = f'{rule_name}_{alt_name[0].upper()}{alt_name[1:]}'
 
             node = UnparserRule(name=rule_name)
             assert node.name, 'Node name of a parser rule is empty or None.'
             for child in (antlr_node.children or []):
                 node += self.antlr_to_grammarinator_tree(child, parser, visited)
         else:
-            assert isinstance(antlr_node, TerminalNode), 'An ANTLR node must either be a ParserRuleContext or a TerminalNode but {node_cls} was found.'.format(node_cls=antlr_node.__class__.__name__)
+            assert isinstance(antlr_node, TerminalNode), f'An ANTLR node must either be a ParserRuleContext or a TerminalNode but {antlr_node.__class__.__name__} was found.'
             name, text = (parser.symbolicNames[antlr_node.symbol.type], antlr_node.symbol.text) if antlr_node.symbol.type != Token.EOF else ('EOF', '')
-            assert name, '{name} is None or empty'.format(name=name)
+            assert name, f'{name} is None or empty'
 
             if not self.hidden:
                 node = UnlexerRule(name=name, src=text)
@@ -122,9 +120,9 @@ class ParserFactory(object):
 
                 return tree
 
-            logger.warning('%s syntax errors detected%s.', parser._syntaxErrors, ' in {fn}'.format(fn=fn) if fn else '')
+            logger.warning('%s syntax errors detected%s.', parser._syntaxErrors, f' in {fn}' if fn else '')
         except Exception as e:
-            logger.warning('Exception while parsing%s.', ' {fn}'.format(fn=fn) if fn else '', exc_info=e)
+            logger.warning('Exception while parsing%s.', f' {fn}' if fn else '', exc_info=e)
         return None
 
     def tree_from_file(self, fn, rule, out, encoding):
@@ -178,7 +176,7 @@ def execute():
 
     for grammar in args.grammar:
         if not exists(grammar):
-            parser.error('{grammar} does not exist.'.format(grammar=grammar))
+            parser.error(f'{grammar} does not exist.')
 
     if not args.parser_dir:
         args.parser_dir = join(args.out, 'grammars')

--- a/grammarinator/parser_builder.py
+++ b/grammarinator/parser_builder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -64,10 +64,10 @@ def build_grammars(in_files, out, antlr):
                 filter(lambda x: len(commonprefix([filename, x])) > 0 and x.endswith(end_pattern), files))[0])[1])[0]
 
         # Extract the name of lexer and parser from their path.
-        lexer = file_endswith('Lexer.{ext}'.format(ext=languages['python']['ext']))
-        parser = file_endswith('Parser.{ext}'.format(ext=languages['python']['ext']))
+        lexer = file_endswith(f'Lexer.{languages["python"]["ext"]}')
+        parser = file_endswith(f'Parser.{languages["python"]["ext"]}')
         # The name of the generated listeners differs if Python or other language target is used.
-        listener = file_endswith('{listener_format}.{ext}'.format(listener_format=languages['python']['listener_format'], ext=languages['python']['ext']))
+        listener = file_endswith(f'{languages["python"]["listener_format"]}.{languages["python"]["ext"]}')
 
         # Add the path of the built lexer and parser to the Python path to be available for importing.
         if out not in sys.path:

--- a/grammarinator/process.py
+++ b/grammarinator/process.py
@@ -234,8 +234,8 @@ class GrammarGraph(object):
         return node.id
 
     def add_edge(self, frm, to):
-        assert frm in self.vertices, '{frm} not in vertices.'.format(frm=frm)
-        assert to in self.vertices, '{to} not in vertices.'.format(to=to)
+        assert frm in self.vertices, f'{frm} not in vertices.'
+        assert to in self.vertices, f'{to} not in vertices.'
         self.vertices[frm].out_neighbours.append(self.vertices[to])
 
     def calc_min_depths(self):
@@ -256,7 +256,7 @@ class GrammarGraph(object):
         # Lift the minimal depths of the alternatives to the alternations, where the decision will happen.
         for ident in min_depths:
             if isinstance(self.vertices[ident], AlternationNode):
-                assert all(min_depths[node.id] < inf for node in self.vertices[ident].out_neighbours), '{ident} has an alternative that isn\'t reachable.'.format(ident=ident)
+                assert all(min_depths[node.id] < inf for node in self.vertices[ident].out_neighbours), f'{ident!r} has an alternative that is not reachable.'
                 min_depths[ident] = [min_depths[node.id] for node in self.vertices[ident].out_neighbours]
 
         # Remove the lifted Alternatives and check for infinite derivations.
@@ -264,7 +264,7 @@ class GrammarGraph(object):
             if isinstance(self.vertices[ident], AlternativeNode):
                 del min_depths[ident]
             else:
-                assert min_depths[ident] != inf, 'Rule with infinite derivation: %s' % ident
+                assert min_depths[ident] != inf, f'Rule with infinite derivation {ident!r}'
 
         for ident, min_depth in min_depths.items():
             self.vertices[ident].min_depth = min_depth
@@ -407,7 +407,7 @@ def build_graph(actions, lexer_root, parser_root):
 
         if node.TOKEN_REF():
             src = str(node.TOKEN_REF())
-            assert graph.vertices[src].start_ranges is not None, '{src} has no character start ranges.'.format(src=src)
+            assert graph.vertices[src].start_ranges is not None, f'{src} has no character start ranges.'
             return graph.vertices[src].start_ranges
 
         return []
@@ -745,13 +745,13 @@ def execute():
 
     for grammar in args.grammar:
         if not exists(grammar):
-            parser.error('{grammar} does not exist.'.format(grammar=grammar))
+            parser.error(f'{grammar} does not exist.')
 
     options = {}
     for option in args.options:
         parts = re.fullmatch('([^=]+)=(.*)', option)
         if not parts:
-            parser.error('option not in OPT=VAL format: {option}'.format(option=option))
+            parser.error(f'option not in OPT=VAL format: {option}')
 
         name, value = parts.group(1, 2)
         options[name] = value

--- a/grammarinator/runtime/default_model.py
+++ b/grammarinator/runtime/default_model.py
@@ -12,13 +12,7 @@ class DefaultModel(object):
 
     def choice(self, node, idx, weights):
         # assert sum(weights) > 0, 'Sum of weights is zero.'
-        r = random.uniform(0, sum(weights))
-        upto = 0
-        for i, w in enumerate(weights):
-            if upto + w >= r:
-                return i
-            upto += w
-        raise AssertionError('Shouldn\'t get here.')
+        return random.choices(range(len(weights)), weights=weights)[0]
 
     def quantify(self, node, idx, min, max):
         cnt = 0

--- a/grammarinator/runtime/tree.py
+++ b/grammarinator/runtime/tree.py
@@ -71,7 +71,7 @@ class Tree(object):
     def print(self):
         def _walk(node):
             nonlocal indent
-            print('%s%s' % ('  ' * indent, node.name or getattr(node, 'src', None)))
+            print(f'{"  " * indent}{node.name or getattr(node, "src", None)}')
             if isinstance(node, UnparserRule):
                 indent += 1
                 for child in node.children:
@@ -168,7 +168,7 @@ class BaseRule(object):
         result = [child for child in self.children if child.name == item]
 
         if not result:
-            raise AttributeError('No child with name \'{name}\'.'.format(name=item))
+            raise AttributeError(f'No child with name {item!r}.')
 
         return result[0] if len(result) == 1 else result
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,11 +14,12 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing
 platform = any
@@ -26,7 +27,7 @@ platform = any
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.5
+python_requires = >=3.6
 install_requires =
     antlerinator>=1!1.0.0
     antlr4-python3-runtime==4.9.2

--- a/tests/parse.py
+++ b/tests/parse.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -20,13 +20,13 @@ logger = logging.getLogger('grammarinator')
 
 
 def parse(lexer_cls, parser_cls, rule, infile, encoding):
-    logger.info('Parsing {infile}'.format(infile=infile))
+    logger.info('Parsing %s', infile)
 
     parser = parser_cls(CommonTokenStream(lexer_cls(FileStream(infile, encoding=encoding))))
     getattr(parser, rule)()
 
     if parser._syntaxErrors > 0:
-        logger.error('Parse error in {infile}'.format(infile=infile))
+        logger.error('Parse error in %s', infile)
     return parser._syntaxErrors
 
 
@@ -59,7 +59,7 @@ def execute():
 
     if '%d' not in args.infile:
         base, ext = splitext(args.infile)
-        args.infile = '{base}%d{ext}'.format(base=base, ext=ext) if ext else join(base, '%d')
+        args.infile = f'{base}%d{ext}' if ext else join(base, '%d')
 
     args.infile = args.infile.replace('%d', '*')
 
@@ -77,7 +77,7 @@ def execute():
         errors += parse(lexer_cls, parser_cls, args.rule, infile, args.encoding)
 
     if not parsed:
-        logger.error('No input file found for pattern {infile}'.format(infile=args.infile))
+        logger.error('No input file found for pattern %s', args.infile)
         errors += 1
 
     if errors > 0:

--- a/tests/run_grammars.py
+++ b/tests/run_grammars.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -72,7 +72,7 @@ def run_subprocess(grammar, commandline, tmpdir):
 
     commandline = commandline.format(grammar=grammar_name, tmpdir=tmpdir)
 
-    print('RUN: %s' % commandline)
+    print(f'RUN: {commandline}')
     subprocess.run(shlex.split(commandline, posix=sys.platform != 'win32'),
                    cwd=grammar_dir, env=env, check=True)
 
@@ -87,10 +87,7 @@ def run_process(grammar, commandline, tmpdir):
     :param commandline: command line as specified in the test command.
     :param tmpdir: path to a temporary directory (provided by the environment).
     """
-    run_subprocess(grammar,
-                   '{python} -m grammarinator.process {commandline}'
-                   .format(python=sys.executable, commandline=commandline),
-                   tmpdir)
+    run_subprocess(grammar, f'{sys.executable} -m grammarinator.process {commandline}', tmpdir)
 
 
 def run_generate(grammar, commandline, tmpdir):
@@ -103,10 +100,7 @@ def run_generate(grammar, commandline, tmpdir):
     :param commandline: command line as specified in the test command.
     :param tmpdir: path to a temporary directory (provided by the environment).
     """
-    run_subprocess(grammar,
-                   '{python} -m grammarinator.generate {commandline}'
-                   .format(python=sys.executable, commandline=commandline),
-                   tmpdir)
+    run_subprocess(grammar, f'{sys.executable} -m grammarinator.generate {commandline}', tmpdir)
 
 
 def run_antlr(grammar, commandline, tmpdir):
@@ -120,10 +114,7 @@ def run_antlr(grammar, commandline, tmpdir):
     :param tmpdir: path to a temporary directory (provided by the environment).
     """
     antlr_jar_path = antlerinator.download(lazy=True)
-    run_subprocess(grammar,
-                   'java -jar {antlr} -Dlanguage=Python3 {commandline}'
-                   .format(antlr=antlr_jar_path, commandline=commandline),
-                   tmpdir)
+    run_subprocess(grammar, f'java -jar {antlr_jar_path} -Dlanguage=Python3 {commandline}', tmpdir)
 
 
 def run_parse(grammar, commandline, tmpdir):
@@ -136,10 +127,7 @@ def run_parse(grammar, commandline, tmpdir):
     :param commandline: command line as specified in the test command.
     :param tmpdir: path to a temporary directory (provided by the environment).
     """
-    run_subprocess(grammar,
-                   '{python} {parser} {commandline}'
-                   .format(python=sys.executable, parser=os.path.join(tool_dir, 'parse.py'), commandline=commandline),
-                   tmpdir)
+    run_subprocess(grammar, f'{sys.executable} {os.path.join(tool_dir, "parse.py")} {commandline}', tmpdir)
 
 
 command_runner = {


### PR DESCRIPTION
Python3.5 has reached the end of its lifetime two years ago, hence Grammarinator also stops supporting it. The patch introduces several Python3.6 features like the usage of f-strings or random.choices() and it updates the docs and tests.