### PR TITLE
Re-enable the 'consider-using-f-string' pylint checker

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -27,7 +27,6 @@ disable=
     too-many-instance-attributes, too-few-public-methods,
     redefined-builtin, broad-except, protected-access,
     useless-object-inheritance, deprecated-module, unspecified-encoding,
-    consider-using-f-string
 
 [REPORTS]
 


### PR DESCRIPTION
Grammarinator uses f-strings since #63 hence executing the linter checker above is reasonable.