### PR TITLE
Add grammar analyzer functionality to grammarinator-process

### DIFF
--- a/grammarinator/generate.py
+++ b/grammarinator/generate.py
@@ -227,7 +227,7 @@ def execute():
     parser.add_argument('generator', metavar='NAME',
                         help='reference to the generator created by grammarinator-process (in package.module.class format).')
     parser.add_argument('-r', '--rule', metavar='NAME',
-                        help='name of the rule to start generation from (default: first parser rule).')
+                        help='name of the rule to start generation from (default: the parser rule set by grammarinator-process).')
     parser.add_argument('-m', '--model', metavar='NAME', default='grammarinator.runtime.DefaultModel',
                         help='reference to the decision model (in package.module.class format) (default: %(default)s).')
     parser.add_argument('-l', '--listener', metavar='NAME', action='append', default=[],

--- a/grammarinator/resources/codegen/GeneratorTemplate.py.jinja
+++ b/grammarinator/resources/codegen/GeneratorTemplate.py.jinja
@@ -63,7 +63,7 @@ with AlternationContext(self, [{{ node.min_depth | join(', ') }}], [{{ node.cond
     [{% for rule in simple_rules %}self.{{ rule }}{% if not loop.last %}, {% endif %}{% endfor %}][choice{{ node.idx }}](parent=current)
     {% else %}
     {% for child in node.out_neighbours %}
-    {{ 'if' if loop.index0 == 0 else 'elif' }} choice{{ node.idx }} == {{ loop.index0 }}:
+    {{ 'if' if loop.index0 == 0 else 'elif' }} choice{{ node.idx }} == {{ child.idx }}:
         {{ processNode(child) | indent | indent -}}
     {% endfor %}
     {% endif %}


### PR DESCRIPTION
This new funcionality helps identifying cycles in the graph and it looks for unavailable rules from a user-defined start rule. Furthermore, it finds the farthest rule from a starting rule
- this can be predefined or the first parser rule. This information can be useful by generation when parametrizing the max-depth argument. The node classes representing the grammar tree are extended with __str__ and print_tree methods.