### PR TITLE
ANTLeRinator 1!3.0.0 doesn't clean generated files before sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+exclude grammarinator/parser/ANTLRv4*.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "antlerinator>=1!1.1.0",
+    "antlerinator>=1!3.0.0",
     "setuptools",
     "setuptools_scm[toml]",
     "wheel",

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find:
 include_package_data = True
 python_requires = >=3.6
 install_requires =
-    antlerinator>=1!1.0.0
+    antlerinator>=1!3.0.0
     antlr4-python3-runtime==4.9.2
     autopep8
     importlib-metadata; python_version < "3.8"

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     pylint
 commands =
     pylint grammarinator
-    pycodestyle grammarinator --ignore=E501
+    pycodestyle grammarinator --ignore=E501 --exclude=grammarinator/parser/ANTLRv4*.py
 
 [testenv:build]
 deps =


### PR DESCRIPTION
This helps running tox when working with a development mode install, but requires adding a manifest template.