### PR TITLE
Drop support of Python3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,13 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
-        exclude:
-          - python-version: 3.6
-            os: ubuntu-latest
-        include:
-          - python-version: 3.6
-            os: ubuntu-20.04
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
     runs-on: ${{ matrix.os }}
     steps:
       - run: git config --global core.autocrlf input

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ The `trophy page`_ of the found issues is available from the wiki.
 Requirements
 ============
 
-* Python_ >= 3.6
+* Python_ >= 3.7
 * Java_ SE >= 7 JRE or JDK (the latter is optional)
 
 .. _Python: https://www.python.org

--- a/grammarinator/generate.py
+++ b/grammarinator/generate.py
@@ -12,7 +12,7 @@ import os
 import random
 
 from argparse import ArgumentParser, ArgumentTypeError, SUPPRESS
-from contextlib import contextmanager
+from contextlib import nullcontext
 from functools import partial
 from itertools import count
 from math import inf
@@ -45,11 +45,6 @@ class Population(object):
     @property
     def size(self):
         return len(self.obj_list)
-
-
-@contextmanager
-def nullcontext():
-    yield None
 
 
 class Generator(object):

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -27,7 +26,7 @@ platform = any
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     antlerinator>=1!3.0.0
     antlr4-python3-runtime==4.9.2


### PR DESCRIPTION
Python3.6 has reached the end of its lifetime more than a year ago, hence Grammarinator also stops supporting it.
Since contextlib supports nullcontext as default from python3.7, Grammarinator starts using it instead of defining it on its own version.