### PR TITLE
Simplify GeneratorTool by removing the complexity of generator instantiation

### DIFF
--- a/grammarinator/tool/__init__.py
+++ b/grammarinator/tool/__init__.py
@@ -5,6 +5,6 @@
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-from .generator import GeneratorTool
+from .generator import DefaultGeneratorFactory, GeneratorTool
 from .parser import ParserTool
 from .processor import ProcessorTool


### PR DESCRIPTION
Instead of requiring several hard-coded parameters to guide the instantiation of the generator with a specific set of models and a given set of listeners, all that logic is encapsulated into a so-called generator factory.

A generator factory is a generalization of a generator class: it has to instantiate a generator object. But it has to set the decision model and the listeners of the generator as well. (In the simplest case, it can be a generator class, but in more complex scenarios - like the `grammarinator-generate` script - some wrapper is needed.)

This generalization helps to greatly simplify the API of the `GeneratorTool` and also simplifies its internal implementation.

Also moved the responsibility of reproducibility from the tool to the script.

Also removed the support for string parameters in
`GeneratorTool.__init.__`. Passing a generator factory as a string is not possible, so other parameters should not bother about string values either. Integration into the Fuzzinator framework should be implemented separately.