### PR TITLE
Add support for encoding error handling

### DIFF
--- a/grammarinator/cli.py
+++ b/grammarinator/cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2020-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -23,3 +23,13 @@ def add_jobs_argument(parser):
 def add_disable_cleanup_argument(parser):
     parser.add_argument('--disable-cleanup', dest='cleanup', default=True, action='store_false',
                         help='disable the removal of intermediate files.')
+
+
+def add_encoding_argument(parser, help):
+    parser.add_argument('--encoding', metavar='NAME', default='utf-8',
+                        help=help)
+
+
+def add_encoding_errors_argument(parser):
+    parser.add_argument('--encoding-errors', metavar='NAME', default='strict',
+                        help='encoding error handling scheme (default: %(default)s).')

--- a/grammarinator/generate.py
+++ b/grammarinator/generate.py
@@ -19,7 +19,7 @@ from os.path import abspath, exists, isdir, join
 from inators.arg import add_log_level_argument, add_sys_path_argument, add_sys_recursion_limit_argument, add_version_argument, process_log_level_argument, process_sys_path_argument, process_sys_recursion_limit_argument
 from inators.imp import import_object
 
-from .cli import add_jobs_argument, init_logging, logger
+from .cli import add_encoding_argument, add_encoding_errors_argument, add_jobs_argument, init_logging, logger
 from .pkgdata import __version__
 from .tool import DefaultGeneratorFactory, GeneratorTool
 
@@ -72,7 +72,7 @@ def generator_tool_helper(args, weights, lock):
                          max_depth=args.max_depth,
                          population=args.population, generate=args.generate, mutate=args.mutate, recombine=args.recombine, keep_trees=args.keep_trees,
                          transformers=args.transformer, serializer=args.serializer,
-                         cleanup=False, encoding=args.encoding)
+                         cleanup=False, encoding=args.encoding, errors=args.encoding_errors)
 
 
 def create_test(generator_tool, index, *, seed):
@@ -123,14 +123,14 @@ def execute():
     # Auxiliary settings.
     parser.add_argument('-o', '--out', metavar='FILE', default=join(os.getcwd(), 'tests', 'test_%d'),
                         help='output file name pattern (default: %(default)s).')
-    parser.add_argument('--encoding', metavar='ENC', default='utf-8',
-                        help='output file encoding (default: %(default)s).')
     parser.add_argument('--stdout', dest='out', action='store_const', const='', default=SUPPRESS,
                         help='print test cases to stdout (alias for --out=%(const)r)')
     parser.add_argument('-n', default=1, type=int, metavar='NUM',
                         help='number of tests to generate, \'inf\' for continuous generation (default: %(default)s).')
     parser.add_argument('--random-seed', type=int, metavar='NUM',
                         help='initialize random number generator with fixed seed (not set by default).')
+    add_encoding_argument(parser, help='output file encoding (default: %(default)s).')
+    add_encoding_errors_argument(parser)
     add_jobs_argument(parser)
     add_sys_path_argument(parser)
     add_sys_recursion_limit_argument(parser)

--- a/grammarinator/parse.py
+++ b/grammarinator/parse.py
@@ -15,14 +15,14 @@ from os.path import exists, join
 from antlerinator import add_antlr_argument, process_antlr_argument
 from inators.arg import add_log_level_argument, add_sys_path_argument, add_sys_recursion_limit_argument, add_version_argument, process_log_level_argument, process_sys_path_argument, process_sys_recursion_limit_argument
 
-from .cli import add_disable_cleanup_argument, add_jobs_argument, init_logging, logger
+from .cli import add_disable_cleanup_argument, add_encoding_argument, add_encoding_errors_argument, add_jobs_argument, init_logging, logger
 from .pkgdata import __version__
 from .tool import ParserTool
 
 
-def iterate_tests(files, rule, out, encoding):
+def iterate_tests(files, rule, out, encoding, errors):
     for test in files:
-        yield (test, rule, out, encoding)
+        yield (test, rule, out, encoding, errors)
 
 
 def execute():
@@ -42,14 +42,14 @@ def execute():
                         help='reference to a transformer (in package.module.function format) to postprocess the parsed tree.')
     parser.add_argument('--hidden', metavar='NAME', action='append', default=[],
                         help='list of hidden tokens to be built into the parsed tree.')
-    parser.add_argument('--encoding', metavar='ENC', default='utf-8',
-                        help='input file encoding (default: %(default)s).')
     parser.add_argument('--max-depth', type=int, default=inf,
                         help='maximum expected tree depth (deeper tests will be discarded (default: %(default)f)).')
     parser.add_argument('-o', '--out', metavar='DIR', default=os.getcwd(),
                         help='directory to save the trees (default: %(default)s).')
     parser.add_argument('--parser-dir', metavar='DIR',
                         help='directory to save the parser grammars (default: <OUTDIR>/grammars).')
+    add_encoding_argument(parser, help='input file encoding (default: %(default)s).')
+    add_encoding_errors_argument(parser)
     add_disable_cleanup_argument(parser)
     add_jobs_argument(parser)
     add_antlr_argument(parser)
@@ -76,9 +76,9 @@ def execute():
                     max_depth=args.max_depth, cleanup=args.cleanup) as parser:
         if args.jobs > 1:
             with Pool(args.jobs) as pool:
-                pool.starmap(parser.parse, iterate_tests(args.input, args.rule, args.out, args.encoding))
+                pool.starmap(parser.parse, iterate_tests(args.input, args.rule, args.out, args.encoding, args.encoding_errors))
         else:
-            for create_args in iterate_tests(args.input, args.rule, args.out, args.encoding):
+            for create_args in iterate_tests(args.input, args.rule, args.out, args.encoding, args.encoding_errors):
                 parser.parse(*create_args)
 
 

--- a/grammarinator/process.py
+++ b/grammarinator/process.py
@@ -14,7 +14,7 @@ from os.path import exists
 
 from inators.arg import add_log_level_argument, add_version_argument, process_log_level_argument
 
-from .cli import init_logging, logger
+from .cli import add_encoding_argument, add_encoding_errors_argument, init_logging, logger
 from .pkgdata import __version__
 from .tool import ProcessorTool
 
@@ -36,14 +36,14 @@ def execute():
                         help='do not process inline actions.')
     parser.add_argument('--rule', '-r', metavar='NAME',
                         help='default rule to start generation from (default: the first parser rule)')
-    parser.add_argument('--encoding', metavar='ENC', default='utf-8',
-                        help='grammar file encoding (default: %(default)s).')
     parser.add_argument('--lib', metavar='DIR',
                         help='alternative location of import grammars.')
     parser.add_argument('--pep8', default=False, action='store_true',
                         help='enable autopep8 to format the generated fuzzer.')
     parser.add_argument('-o', '--out', metavar='DIR', default=getcwd(),
                         help='temporary working directory (default: %(default)s).')
+    add_encoding_argument(parser, help='grammar file encoding (default: %(default)s).')
+    add_encoding_errors_argument(parser)
     add_log_level_argument(parser, short_alias=())
     add_version_argument(parser, version=__version__)
     args = parser.parse_args()
@@ -64,7 +64,7 @@ def execute():
     init_logging()
     process_log_level_argument(args, logger)
 
-    ProcessorTool(args.language, args.out).process(args.grammar, options=options, default_rule=args.rule, encoding=args.encoding, lib_dir=args.lib, actions=args.actions, pep8=args.pep8)
+    ProcessorTool(args.language, args.out).process(args.grammar, options=options, default_rule=args.rule, encoding=args.encoding, errors=args.encoding_errors, lib_dir=args.lib, actions=args.actions, pep8=args.pep8)
 
 
 if __name__ == '__main__':

--- a/grammarinator/tool/generator.py
+++ b/grammarinator/tool/generator.py
@@ -137,7 +137,7 @@ class GeneratorTool(object):
     def __init__(self, generator_factory, rule, out_format, lock=None, max_depth=inf,
                  population=None, generate=True, mutate=True, recombine=True, keep_trees=False,
                  transformers=None, serializer=None,
-                 cleanup=True, encoding='utf-8'):
+                 cleanup=True, encoding='utf-8', errors='strict'):
         """
         :param generator_factory: A callable that can produce instances of a
             generator. It is a generalization of a generator class: it has to
@@ -166,6 +166,7 @@ class GeneratorTool(object):
                See :func:`grammarinator.runtime.simple_space_serializer` for a simple solution that concatenates tokens with spaces.
         :param bool cleanup: Enable deleting the generated tests at :meth:`__exit__`.
         :param str encoding: Output file encoding.
+        :param str errors: Encoding error handling scheme.
         """
 
         self._generator_factory = generator_factory
@@ -186,6 +187,7 @@ class GeneratorTool(object):
         self._keep_trees = keep_trees
         self._cleanup = cleanup
         self._encoding = encoding
+        self._errors = errors
 
     def __enter__(self):
         return self
@@ -236,7 +238,7 @@ class GeneratorTool(object):
             tree.save(tree_fn)
 
         if test_fn:
-            with codecs.open(test_fn, 'w', self._encoding) as f:
+            with codecs.open(test_fn, 'w', self._encoding, self._errors) as f:
                 f.write(self._serializer(tree.root))
         else:
             with self._lock:

--- a/grammarinator/tool/parser.py
+++ b/grammarinator/tool/parser.py
@@ -199,7 +199,7 @@ class ParserTool(object):
             logger.warning('Exception while parsing%s.', f' {fn}' if fn else '', exc_info=e)
         return None
 
-    def parse(self, fn, rule, out, encoding):
+    def parse(self, fn, rule, out, encoding, errors):
         """
         Load content from file, parse it to an ANTLR tree, convert it to Grammarinator tree, and save it to file.
 
@@ -208,10 +208,11 @@ class ParserTool(object):
         :param str out: Path to the output directory where the trees will be saved with ``.grt``
                extension.
         :param str encoding: Encoding of the input file.
+        :param str errors: Encoding error handling scheme.
         """
         logger.info('Process file %s.', fn)
         try:
-            tree = self._create_tree(FileStream(fn, encoding=encoding), rule, fn)
+            tree = self._create_tree(FileStream(fn, encoding=encoding, errors=errors), rule, fn)
             if tree is not None:
                 if not tree.save(join(out, basename(fn) + Tree.extension), max_depth=self._max_depth):
                     logger.info('The tree representation of %r is too deep. Skipping.', fn)

--- a/tests/grammars/SurrogatePairs.g4
+++ b/tests/grammars/SurrogatePairs.g4
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Renata Hodovan, Akos Kiss.
+ *
+ * Licensed under the BSD 3-Clause License
+ * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+ * This file may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+
+/*
+ * Tests handling of Unicode surrogate pairs.
+ *
+ * Note:
+ *  - Surrogate pairs can be written but will be converted to complete
+ *    Unicode characters when reading back, so ANTLR is not invoked to generate
+ *    a parser.
+ */
+
+// TEST-PROCESS: {grammar}.g4 -o {tmpdir}
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -o {tmpdir}/{grammar}%d.txt --encoding utf-16 --encoding-errors surrogatepass
+
+grammar SurrogatePairs;
+
+start: SURROGATE NON_BMP ;
+
+SURROGATE: '\ud83d\ude4f' ;
+
+NON_BMP: '\u{01f64f}' ;


### PR DESCRIPTION
The support for encoding error handling has been motivated by errors caused if Unicode surrogate pairs are in the generated tests, which cannot be written to output with utf-8 codec.

Also added a unit test to create a test case with character outside the basic multilingual plane of Unicode, both in six-position-hex format and with surrogate pair.