### PR TITLE
Fix CLI override of the dot grammar option

### DIFF
--- a/grammarinator/tool/processor.py
+++ b/grammarinator/tool/processor.py
@@ -440,8 +440,7 @@ class ProcessorTool(object):
             else:
                 copy(grammar, self._work_dir)
 
-        graph = self._build_graph(actions, lexer_root, parser_root, default_rule)
-        graph.options.update(options or {})
+        graph = self._build_graph(actions, lexer_root, parser_root, options, default_rule)
         self._analyze_graph(graph)
 
         src = self._template.render(graph=graph, version=__version__).lstrip()
@@ -488,7 +487,7 @@ class ProcessorTool(object):
         return imports
 
     @staticmethod
-    def _build_graph(actions, lexer_root, parser_root, default_rule):
+    def _build_graph(actions, lexer_root, parser_root, options, default_rule):
 
         def find_conditions(node):
             if not actions:
@@ -748,13 +747,13 @@ class ProcessorTool(object):
 
                     elif node.notSet():
                         if node.notSet().setElement():
-                            options = chars_from_set(node.notSet().setElement())
+                            not_ranges = chars_from_set(node.notSet().setElement())
                         else:
-                            options = []
+                            not_ranges = []
                             for set_element in node.notSet().blockSet().setElement():
-                                options.extend(chars_from_set(set_element))
+                                not_ranges.extend(chars_from_set(set_element))
 
-                        charset = Charset(multirange_diff(dot_charset.ranges, sorted(options, key=lambda x: x[0])))
+                        charset = Charset(multirange_diff(dot_charset.ranges, sorted(not_ranges, key=lambda x: x[0])))
                         graph.charsets.append(charset)
                         graph.add_edge(frm=parent_id, to=graph.add_node(CharsetNode(rule_id=rule.name, idx=chr_idx, charset=charset.id)))
                         chr_idx += 1
@@ -880,6 +879,7 @@ class ProcessorTool(object):
         for root in [lexer_root, parser_root]:
             if root:
                 build_prequel(root)
+        graph.options.update(options or {})
 
         dot_charset = Charset(Charset.dot[graph.dot])
         graph.charsets.append(dot_charset)

--- a/tests/grammars/DotOption.g4
+++ b/tests/grammars/DotOption.g4
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 Renata Hodovan, Akos Kiss.
+ *
+ * Licensed under the BSD 3-Clause License
+ * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+ * This file may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+
+/*
+ * This test checks whether command-line override of the dot option (`-Ddot=`)
+ * works correctly.
+ */
+
+// TEST-PROCESS: {grammar}.g4 -o {tmpdir} -Ddot=any_ascii_letter
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 --model {grammar}Generator.DotModel -o {tmpdir}/{grammar}.txt
+
+grammar DotOption;
+
+options {
+dot=any_ascii_char;
+}
+
+@header {
+
+from grammarinator.runtime import DispatchingModel
+
+
+class DotModel(DispatchingModel):
+
+    def charset_start(self, node, idx, chars):
+        # dot option in grammar allows any printable 7-bit ASCII character, 0 included
+        # command-line override tries to limit dot to 7-bit ASCII letters, 0 excluded
+        assert ord('0') not in chars, chars
+        return 'a'
+}
+
+
+start : . ;


### PR DESCRIPTION
Options given on the CLI were added too late to the internal representation of the grammar, when the option specified in the grammar file was already taken into account. So, `-Ddot=...` could not override `options { dot=...; }`.