### PR TITLE
Better control of multiprocessing in unit tests

### DIFF
--- a/examples/grammars/HTMLParser.g4
+++ b/examples/grammars/HTMLParser.g4
@@ -27,8 +27,8 @@
 */
 
 // TEST-PROCESS: {grammar}Parser.g4 {grammar}Lexer.g4 -o {tmpdir}
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r htmlDocument -s {grammar}Generator.html_space_serializer -n 5 -o {tmpdir}/{grammar}G%d.html
-// TEST-GENERATE: {grammar}CustomGenerator.{grammar}CustomGenerator -r htmlDocument -s {grammar}Generator.html_space_serializer -n 5 -o {tmpdir}/{grammar}C%d.html --sys-path ../fuzzer/
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r htmlDocument -s {grammar}Generator.html_space_serializer -j 2 -n 5 -o {tmpdir}/{grammar}G%d.html
+// TEST-GENERATE: {grammar}CustomGenerator.{grammar}CustomGenerator -r htmlDocument -s {grammar}Generator.html_space_serializer -j 2 -n 5 -o {tmpdir}/{grammar}C%d.html --sys-path ../fuzzer/
 
 parser grammar HTMLParser;
 

--- a/tests/grammars/Arguments.g4
+++ b/tests/grammars/Arguments.g4
@@ -13,7 +13,8 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -n 5 --stdout
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -n 5 --stdout
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 2 -n 5 --stdout
 
 grammar Arguments;
 

--- a/tests/grammars/Charset.g4
+++ b/tests/grammars/Charset.g4
@@ -13,7 +13,7 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -o {tmpdir}/{grammar}%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -o {tmpdir}/{grammar}%d.txt
 // TEST-ANTLR: {grammar}.g4 -o {tmpdir}
 // TEST-REPARSE: -p {grammar}Parser -l {grammar}Lexer -r start {tmpdir}/{grammar}%d.txt
 

--- a/tests/grammars/Curly.g4
+++ b/tests/grammars/Curly.g4
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 Renata Hodovan, Akos Kiss.
+ * Copyright (c) 2017-2023 Renata Hodovan, Akos Kiss.
  *
  * Licensed under the BSD 3-Clause License
  * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -13,7 +13,7 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -o {tmpdir}/{grammar}%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -o {tmpdir}/{grammar}%d.txt
 // TEST-ANTLR: {grammar}.g4 -o {tmpdir}
 
 grammar Curly;

--- a/tests/grammars/CustomWeightsModel.g4
+++ b/tests/grammars/CustomWeightsModel.g4
@@ -12,7 +12,8 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -n 5 --weights custom_weights.json -o {tmpdir}/{grammar}%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -n 5 --weights custom_weights.json -o {tmpdir}/{grammar}S%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 2 -n 5 --weights custom_weights.json -o {tmpdir}/{grammar}M%d.txt
 
 grammar CustomWeightsModel;
 

--- a/tests/grammars/DefaultRule.g4
+++ b/tests/grammars/DefaultRule.g4
@@ -12,7 +12,7 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -o {tmpdir}/{grammar}%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -o {tmpdir}/{grammar}%d.txt
 // TEST-ANTLR: {grammar}.g4 -o {tmpdir}
 // TEST-REPARSE: -p {grammar}Parser -l {grammar}Lexer -r start {tmpdir}/{grammar}%d.txt
 

--- a/tests/grammars/DispatchingModel.g4
+++ b/tests/grammars/DispatchingModel.g4
@@ -12,7 +12,8 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -n 5 --model {grammar}Generator.CustomModel -o {tmpdir}/{grammar}%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -n 5 --model {grammar}Generator.CustomModel -o {tmpdir}/{grammar}S%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 2 -n 5 --model {grammar}Generator.CustomModel -o {tmpdir}/{grammar}M%d.txt
 
 grammar DispatchingModel;
 

--- a/tests/grammars/EmptyAlternatives.g4
+++ b/tests/grammars/EmptyAlternatives.g4
@@ -13,7 +13,8 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -o {tmpdir}/{grammar}%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -n 5 -o {tmpdir}/{grammar}S%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 2 -n 5 -o {tmpdir}/{grammar}M%d.txt
 // TEST-ANTLR: {grammar}.g4 -o {tmpdir}
 // TEST-REPARSE: -p {grammar}Parser -l {grammar}Lexer -r start {tmpdir}/{grammar}%d.txt
 

--- a/tests/grammars/Eof.g4
+++ b/tests/grammars/Eof.g4
@@ -13,7 +13,7 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -o {tmpdir}/{grammar}%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -o {tmpdir}/{grammar}%d.txt
 // TEST-ANTLR: {grammar}.g4 -o {tmpdir}
 // TEST-REPARSE: -p {grammar}Parser -l {grammar}Lexer -r start {tmpdir}/{grammar}%d.txt
 

--- a/tests/grammars/Hello.g4
+++ b/tests/grammars/Hello.g4
@@ -15,7 +15,7 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir} --pep8
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -o {tmpdir}/{grammar}%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -o {tmpdir}/{grammar}%d.txt
 // TEST-ANTLR: {grammar}.g4 -o {tmpdir}
 // TEST-REPARSE: -p {grammar}Parser -l {grammar}Lexer -r start {tmpdir}/{grammar}%d.txt
 

--- a/tests/grammars/ImagToken.g4
+++ b/tests/grammars/ImagToken.g4
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 Renata Hodovan, Akos Kiss.
+ * Copyright (c) 2017-2023 Renata Hodovan, Akos Kiss.
  *
  * Licensed under the BSD 3-Clause License
  * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -12,7 +12,7 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -o {tmpdir}/{grammar}%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -o {tmpdir}/{grammar}%d.txt
 // TEST-ANTLR: {grammar}.g4 -o {tmpdir}
 
 grammar ImagToken;

--- a/tests/grammars/Importer.g4
+++ b/tests/grammars/Importer.g4
@@ -14,7 +14,7 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir} --lib import
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -o {tmpdir}/{grammar}%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -o {tmpdir}/{grammar}%d.txt
 // TEST-ANTLR: {grammar}.g4 -o {tmpdir} -lib import
 // TEST-REPARSE: -p {grammar}Parser -l {grammar}Lexer -r start {tmpdir}/{grammar}%d.txt
 

--- a/tests/grammars/LifeCycle.g4
+++ b/tests/grammars/LifeCycle.g4
@@ -27,7 +27,7 @@
 // TEST-PARSE: {grammar}.g4 -j 1 -i {tmpdir}/LifeCycleA0.txt {tmpdir}/LifeCycleA1.txt {tmpdir}/LifeCycleA2.txt -r start --hidden WS -o {tmpdir}/population/
 // TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -r start -n 3 --population {tmpdir}/population/ -o {tmpdir}/{grammar}B%d.txt --keep-trees --no-generate --no-recombine
 // TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -r start -n 3 --population {tmpdir}/population/ -o {tmpdir}/{grammar}C%d.txt --keep-trees --no-generate --no-mutate
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -n 6 --population {tmpdir}/population/ -o {tmpdir}/{grammar}D%d.txt --no-generate
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 2 -r start -n 6 --population {tmpdir}/population/ -o {tmpdir}/{grammar}D%d.txt --no-generate
 
 grammar LifeCycle;
 

--- a/tests/grammars/Listeners.g4
+++ b/tests/grammars/Listeners.g4
@@ -13,8 +13,10 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -n 5 --listener grammarinator.runtime.DefaultListener -o {tmpdir}/{grammar}A%d.txt
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -n 5 --listener {grammar}Generator.CustomListener -o {tmpdir}/{grammar}B%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -n 5 --listener grammarinator.runtime.DefaultListener -o {tmpdir}/{grammar}DS%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 2 -n 5 --listener grammarinator.runtime.DefaultListener -o {tmpdir}/{grammar}DM%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -n 5 --listener {grammar}Generator.CustomListener -o {tmpdir}/{grammar}CS%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 2 -n 5 --listener {grammar}Generator.CustomListener -o {tmpdir}/{grammar}CM%d.txt
 
 grammar Listeners;
 

--- a/tests/grammars/Locals.g4
+++ b/tests/grammars/Locals.g4
@@ -13,7 +13,8 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -n 5 --stdout
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -n 5 --stdout
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 2 -n 5 --stdout
 
 grammar Locals;
 

--- a/tests/grammars/MinDepth.g4
+++ b/tests/grammars/MinDepth.g4
@@ -15,7 +15,7 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -n 1 -o {tmpdir}/{grammar}%d.txt -d 2
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -o {tmpdir}/{grammar}%d.txt -d 2
 // TEST-ANTLR: {grammar}.g4 -o {tmpdir}
 // TEST-REPARSE: -p {grammar}Parser -l {grammar}Lexer -r start {tmpdir}/{grammar}%d.txt
 

--- a/tests/grammars/NoAction.g4
+++ b/tests/grammars/NoAction.g4
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 Renata Hodovan, Akos Kiss.
+ * Copyright (c) 2017-2023 Renata Hodovan, Akos Kiss.
  *
  * Licensed under the BSD 3-Clause License
  * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -19,7 +19,7 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir} --no-action
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -o {tmpdir}/{grammar}%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -o {tmpdir}/{grammar}%d.txt
 // TEST-ANTLR: {grammar}.g4 -o {tmpdir}
 
 grammar NoAction;

--- a/tests/grammars/Returns.g4
+++ b/tests/grammars/Returns.g4
@@ -13,7 +13,8 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -n 5 -d=5 --stdout
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -n 5 -d=5 --stdout
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 2 -n 5 -d=5 --stdout
 
 grammar Returns;
 

--- a/tests/grammars/SeparateParser.g4
+++ b/tests/grammars/SeparateParser.g4
@@ -13,7 +13,7 @@
  */
 
 // TEST-PROCESS: {grammar}Parser.g4 {grammar}Lexer.g4 -o {tmpdir}
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -o {tmpdir}/{grammar}%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -o {tmpdir}/{grammar}%d.txt
 // TEST-ANTLR: {grammar}Parser.g4 {grammar}Lexer.g4 -o {tmpdir}
 // TEST-REPARSE: -p {grammar}Parser -l {grammar}Lexer -r start {tmpdir}/{grammar}%d.txt
 

--- a/tests/grammars/SimpleAlternations.g4
+++ b/tests/grammars/SimpleAlternations.g4
@@ -14,7 +14,7 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -o {tmpdir}/{grammar}%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -o {tmpdir}/{grammar}%d.txt
 // TEST-ANTLR: {grammar}.g4 -o {tmpdir}
 // TEST-REPARSE: -p {grammar}Parser -l {grammar}Lexer -r start {tmpdir}/{grammar}%d.txt
 

--- a/tests/grammars/Whitespace.g4
+++ b/tests/grammars/Whitespace.g4
@@ -15,7 +15,7 @@
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -s grammarinator.runtime.simple_space_serializer -o {tmpdir}/{grammar}%d.txt
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -s grammarinator.runtime.simple_space_serializer -o {tmpdir}/{grammar}%d.txt
 // TEST-ANTLR: {grammar}.g4 -o {tmpdir}
 // TEST-REPARSE: -p {grammar}Parser -l {grammar}Lexer -r start {tmpdir}/{grammar}%d.txt
 


### PR DESCRIPTION
The default value for `-j` (number oj jobs) in `grammarinator-generate` is based on the number of CPUs available on the system. This is good (adaptive) in practice but not so good for testing (when reproducibility is preferrable).

Therefore, `-j` is explicitly specified in all unit tests. All unit tests try single-process test case generation (using `-j 1`) and those test cases where multi-process behaviour needs to be tested, do so (using `-j 2`).