### PR TITLE
Add listeners argument to Generator

### DIFF
--- a/grammarinator/runtime/generator.py
+++ b/grammarinator/runtime/generator.py
@@ -65,23 +65,17 @@ class Generator(object):
     and additional internal state used during generation.
     """
 
-    def __init__(self, *, model=None, max_depth=inf):
+    def __init__(self, *, model=None, listeners=None, max_depth=inf):
         """
         :param Model model: Model object responsible for every decision during the generation.
                (default: :class:`DefaultModel`).
+        :param list[Listener] listeners: Listeners that get notified whenever a
+               rule is entered or exited.
         :param int or float max_depth: Maximum depth of the generated tree (default: ``inf``).
         """
         self._model = model or DefaultModel()
         self._max_depth = max_depth
-        self._listeners = []
-
-    def add_listener(self, listener):
-        """
-        Register ``listener`` to the current generator.
-
-        :param Listener listener: Listener object.
-        """
-        self._listeners.append(listener)
+        self._listeners = listeners or []
 
     def _enter_rule(self, node):
         for listener in self._listeners:

--- a/grammarinator/tool/generator.py
+++ b/grammarinator/tool/generator.py
@@ -109,10 +109,11 @@ class DefaultGeneratorFactory(object):
         if self._cooldown < 1 or self._weights:
             model = CooldownModel(model, cooldown=self._cooldown, weights=self._weights, lock=self._lock)
 
-        generator = self._generator_class(model=model, max_depth=max_depth)
-
+        listeners = []
         for listener_class in self._listener_classes:
-            generator.add_listener(listener_class())
+            listeners.append(listener_class())
+
+        generator = self._generator_class(model=model, listeners=listeners, max_depth=max_depth)
 
         return generator
 


### PR DESCRIPTION
This allows to set the list of listeners at generator construction time.

The patch also retires the method add_listener, which had a naming issue (i.e., any member in Generator that is public - does not start with an underscore - may conflict later with a method of a subclass named after a grammar rule).