### PR TITLE
Improve the handling of the `dot` wildcard in parser rules

### DIFF
--- a/docs/guide/grammar_overview.rst
+++ b/docs/guide/grammar_overview.rst
@@ -113,9 +113,13 @@ Alternatives (both in lexer and parser rules) are built from the following eleme
   2) **Literals**: Lexer rules and parser rules in combined grammars
      can define implicit literals by enclosing them in single quotes
      (e.g., ``'literal'``).
-  3) **Dot**: Representing an arbitrary single character. The behavior of the
-     dot can be customized using the ``dot`` option. See the ``dot`` key in
-     `options`_ for details.
+  3) **Dot**: The ``dot`` wildcard behaves differently in parser and in
+     lexer rules. In lexer rules, it represents an arbitrary single character.
+     Its behavior can be customized using the ``dot`` option. See the ``dot``
+     key in `options`_ for details. However, if it is placed in a parser rule,
+     then it represents an arbitrary token of the grammar. Since Grammarinator
+     does not keep track of lexer modes (yet), the token is selected from all
+     tokens available in all lexer modes.
   4) **Parentheses**: Grouping parts of rules using parentheses to create
      blocks (e.g., ``(rule1 | 'literal')``).
   5) **Quantifiers**: Applying quantifiers to references, literals, and blocks

--- a/tests/grammars/Dot.g4
+++ b/tests/grammars/Dot.g4
@@ -8,14 +8,17 @@
  */
 
 /*
- * This test checks whether command-line override of the dot option (`-Ddot=`)
- * works correctly.
+ * The test checks the handling of the ``dot`` wildcard both in lexer and parser
+ * rules. Furthermore, it checks whether command-line override of the lexer dot
+ * option (`-Ddot=`) works correctly.
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir} -Ddot=any_ascii_letter
 // TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 --model {grammar}Generator.DotModel -o {tmpdir}/{grammar}.txt
+// TEST-ANTLR: {grammar}.g4 -o {tmpdir}
+// TEST-REPARSE: -p {grammar}Parser -l {grammar}Lexer -r start {tmpdir}/{grammar}%d.txt
 
-grammar DotOption;
+grammar Dot;
 
 options {
 dot=any_ascii_char;
@@ -28,12 +31,15 @@ from grammarinator.runtime import DispatchingModel
 
 class DotModel(DispatchingModel):
 
-    def charset_start(self, node, idx, chars):
+    def charset_C(self, node, idx, chars):
         # dot option in grammar allows any printable 7-bit ASCII character, 0 included
         # command-line override tries to limit dot to 7-bit ASCII letters, 0 excluded
         assert ord('0') not in chars, chars
-        return 'a'
+        return 'c'
 }
 
 
-start : . ;
+start : A . C;
+A : 'aa' ;
+B : 'bb' ;
+C : . ;


### PR DESCRIPTION
Until now, the `dot` wildcard was handled the same way both in lexer and parser rules: it meant the generation of a single character. But it was wrong. From now, if `dot` is placed in a parser rule, it triggers the generation of a random token, as expected by ANTLR. The only limitation is that lexer modes are not taken into account (for now), since it would cause remarkable complication.