### PR TITLE
Fix several issues with arguments, returns and locals

### DIFF
--- a/grammarinator/tool/resources/codegen/GeneratorTemplate.py.jinja
+++ b/grammarinator/tool/resources/codegen/GeneratorTemplate.py.jinja
@@ -7,6 +7,10 @@
  # according to those terms.
  #}
 
+{% macro resolveVarRefs(src) %}
+{{ src | substitute('\$(?P<var_name>\\w+)', 'local_ctx[\'\\g<var_name>\']') -}}
+{% endmacro %}
+
 {% macro processVariableNode(node, args) %}
 local_ctx['{{ node.name }}']{% if node.is_list %}.append(current.last_child){% else %} = current.last_child{% endif %}
 
@@ -14,7 +18,7 @@ local_ctx['{{ node.name }}']{% if node.is_list %}.append(current.last_child){% e
 
 
 {% macro processActionNode(node, args) %}
-{{ node.src | substitute('\$(?P<var_name>\\w+)', 'local_ctx[\'\\g<var_name>\']') }}
+{{ resolveVarRefs(node.src) }}
 {% endmacro %}
 
 
@@ -24,7 +28,7 @@ pass
 
 
 {% macro processRuleNode(node, args) %}
-self.{{ node.id }}({% if args %}{% for k, v in args.items() %}{{ k }}{% if v %}={{ v }}{% endif %}, {% endfor %}{% endif %}parent=current)
+self.{{ node.id }}({% if args %}{% for k, v in args %}{% if k %}{{ k }}={% endif %}{{ resolveVarRefs(v) }}, {% endfor %}{% endif %}parent=current)
 {% endmacro %}
 
 
@@ -48,7 +52,7 @@ if self._max_depth >= {{ node.min_depth }}:
 
 
 {% macro processAlternationNode(node, args) %}
-with AlternationContext(self, [{{ node.min_depths | join(', ') }}], [{{ node.conditions | join(', ') | substitute('\$(?P<var_name>\\w+)', 'local_ctx[\'\\g<var_name>\']') }}]) as weights{{ node.idx }}:
+with AlternationContext(self, [{{ node.min_depths | join(', ') }}], [{{ resolveVarRefs(node.conditions | join(', ')) }}]) as weights{{ node.idx }}:
     choice{{ node.idx }} = self._model.choice(current, {{ node.idx }}, weights{{ node.idx }})
     {% set simple_lits, simple_rules = node.simple_alternatives() %}
     {% if simple_lits and simple_rules %}
@@ -130,17 +134,17 @@ class {{ graph.name }}({{ graph.superclass }}):
     {% endif %}
 
     {% for rule in graph.rules %}
-    def {{ rule.id }}(self, {% for key, value in rule.args.items() %}{{ key }}={{ value }}, {% endfor %}parent=None):
+    def {{ rule.id }}(self, {% for k, v in rule.args %}{{ k }}{% if v %}={{ resolveVarRefs(v) }}{% endif %}, {% endfor %}parent=None):
         {% if rule.id != 'EOF' %}
-        {% if rule.has_var %}
-        local_ctx = dict({% for key, value in rule.attributes.items() %}{{ key }}={% if key in rule.args %}{{ key }}{% else %}{{ value }}{% endif %}{% if not loop.last or rule.labels %}, {% endif %}{% endfor %}{% for name, is_list in rule.labels.items() %}{{ name }}={% if is_list %}[]{% else %}None{% endif %}{% if not loop.last %}, {% endif %}{% endfor %})
+        {% if rule.labels or rule.args or rule.locals or rule.returns %}
+        local_ctx = dict({% for k, _ in rule.args %}{{ k }}={{ k }}{% if not loop.last %}, {% endif %}{% endfor %}{% if rule.args and (rule.locals + rule.returns) %}, {% endif %}{% for k, v in (rule.locals + rule.returns) %}{{ k }}{% if v %}={{ resolveVarRefs(v) }}{% endif %}{% if not loop.last or rule.labels %}, {% endif %}{% endfor %}{% for name, is_list in rule.labels.items() %}{{ name }}={% if is_list %}[]{% else %}None{% endif %}{% if not loop.last %}, {% endif %}{% endfor %})
         {% endif %}
         with {{ rule.type }}Context(self, name='{{ rule.id }}', parent=parent) as current:
             {% for edge in rule.out_edges %}
             {{ processNode(edge.dst, edge.args) | indent | indent | indent -}}
             {% endfor %}
-            {% for ret in rule.returns %}
-            current.{{ ret }} = local_ctx['{{ ret }}']
+            {% for k, _ in rule.returns %}
+            current.{{ k }} = local_ctx['{{ k }}']
             {% endfor %}
             return current
         {% else %}

--- a/tests/grammars/Arguments.g4
+++ b/tests/grammars/Arguments.g4
@@ -9,7 +9,8 @@
 
 /*
  * This test checks whether parser rule arguments are propagated
- * properly down in the tree.
+ * properly down in the tree. Plus it checks the parsing of more
+ * complex argument lists.
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
@@ -19,11 +20,11 @@
 grammar Arguments;
 
 start
-    : res=expr['int'] {assert str($res) == "len(list('string'))"}
+    : res=expr['int', [1, 2, 3]] {assert str($res) == "len(list('string'))"}
     ;
 
-expr args[typ]
-    : {$typ == 'int'}? 'len(' expr['list'] ')'
-    | {$typ == 'list'}? 'list(' expr['string'] ')'
+expr[typ='no=ne', unused='none']
+    : {$typ == 'int'}? 'len(' expr['list', [(v * 2) for k, v in {'a<=c': 10, 'b\'c': 20}.items()]] ')'
+    | {$typ == 'list'}? 'list(' expr['string', [3 < 2, (1 + 1) * 4, 10 / 2]] ')'
     | {$typ == 'string'}? '\'string\''
     ;

--- a/tests/grammars/Returns.g4
+++ b/tests/grammars/Returns.g4
@@ -31,7 +31,7 @@ start
     : res=expr '==' v=VAR {$v.src = str($res.result); assert(eval(str($res))) == float(str($res.result));}
     ;
 
-expr returns [result]
+expr returns [result=0]
     : '(' op1=expr op='*' op2=expr ')' {$result = exec_op($op1.result, str($op), $op2.result)}
     | '(' op1=expr op=('+' | '-') op2=expr ')' {$result = exec_op($op1.result, str($op), $op2.result)}
     | num=Number {$result = float(str($num))}


### PR DESCRIPTION
* Support more complex argument lists for actions: The previous implementation was not prepared for having commas inside the parameter definitions, hence splitted list-like constructs in a wrong way. The patch fixes this.
* Makes sure that variable references are properly resolved in arguments, returns and locals.
* Fix typo in Arguments.g4 test.