### PR TITLE
Migrating to build.os on ReadTheDocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,10 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: 3
+
 python:
   install:
     - method: pip


### PR DESCRIPTION
Both build.os and build.tools became mandatory. The builds on RTD will stop working without them after Oct 16, 2023.