### PR TITLE
Fix build.tools.python in ReadTheDocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: 3
+    python: "3"
 
 python:
   install:


### PR DESCRIPTION
Use string values as per readthedocs/readthedocs.org#10800