### PR TITLE
Avoid setup-java step on GH Actions if possible

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           java-version: 17
           distribution: temurin
+        if: matrix.os == 'windows-latest'
       - run: pip install --upgrade tox
       - run: tox -v -e py
 
@@ -44,10 +45,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-      - uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: temurin
       - run: pip install --upgrade tox coveralls
       - run: tox -v -e cov
       - run: coveralls --service=github


### PR DESCRIPTION
All GH Action runner images have Java pre-installed. Both ubuntu-latest and macos-latest have Java 11+ as default. Only windows-latest has Java 8 as default. So avoid a superfluous setup-java step in all jobs except the tests on windows-latest.