### PR TITLE
Enable splitting long conditions into multiple lines

### DIFF
--- a/grammarinator/tool/default_population.py
+++ b/grammarinator/tool/default_population.py
@@ -241,4 +241,8 @@ class DefaultPopulation(Population):
     # Filter items from ``nodes`` that can be regenerated within the current
     # maximum depth (except 'EOF' and '<INVALID>' nodes).
     def _filter_nodes(self, tree, nodes, max_depth):
-        return [node for node in nodes if node.name is not None and node.parent is not None and node.name not in ['EOF', '<INVALID>'] and tree.node_levels[node] + self._min_depths.get(node.name, 0) < max_depth]
+        return [node for node in nodes
+                if node.name is not None
+                and node.parent is not None
+                and node.name not in ['EOF', '<INVALID>']
+                and tree.node_levels[node] + self._min_depths.get(node.name, 0) < max_depth]

--- a/grammarinator/tool/processor.py
+++ b/grammarinator/tool/processor.py
@@ -161,7 +161,11 @@ class AlternationNode(Node):
         # contains both simple literals and rule references, then both elements of
         # the tuple are lists, which are of identical length, and exactly one of
         # them contains a non-None value at every index position.
-        if not self.out_neighbours or any(len(alt.out_neighbours) != 1 or not isinstance(alt.out_neighbours[0], (LiteralNode, RuleNode)) or (isinstance(alt.out_neighbours[0], RuleNode) and alt.out_edges[0].args) for alt in self.out_neighbours):
+        if (not self.out_neighbours
+            or any(len(alt.out_neighbours) != 1
+                   or not isinstance(alt.out_neighbours[0], (LiteralNode, RuleNode))
+                   or (isinstance(alt.out_neighbours[0], RuleNode) and alt.out_edges[0].args)
+                   for alt in self.out_neighbours)):
             return None, None
 
         simple_lits = [alt.out_neighbours[0].src if isinstance(alt.out_neighbours[0], LiteralNode) else None for alt in self.out_neighbours]

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     pylint
 commands =
     pylint grammarinator
-    pycodestyle grammarinator --ignore=E501 --exclude=grammarinator/tool/g4/ANTLRv4*.py
+    pycodestyle grammarinator --ignore=E501,W503 --exclude=grammarinator/tool/g4/ANTLRv4*.py
 
 [testenv:docs]
 deps = -rdocs/requirements.txt


### PR DESCRIPTION
Disabling W503 which complained about line breaks before binary operators.