### PR TITLE
Remove the explicit `object` superclass definition from classes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -37,7 +37,6 @@ disable=
     too-many-return-statements,
     too-many-statements,
     unspecified-encoding,
-    useless-object-inheritance,
     useless-option-value,  # disables warning in recent pylint that does not check for no-self-use anymore
 
 [REPORTS]

--- a/grammarinator/runtime/generator.py
+++ b/grammarinator/runtime/generator.py
@@ -15,7 +15,7 @@ from .rule import RuleSize, UnlexerRule, UnparserRule
 logger = logging.getLogger(__name__)
 
 
-class RuleContext(object):
+class RuleContext:
     # Context manager wrapping rule generations. It is responsible for
     # keeping track of the value of `max_depth` and for transitively calling the
     # enter and exit methods of the registered listeners.
@@ -72,7 +72,7 @@ class UnparserRuleContext(RuleContext):
         super().__init__(gen, UnparserRule(name=name, parent=parent))
 
 
-class AlternationContext(object):
+class AlternationContext:
     # Context manager wrapping alternations. It is responsible for filtering
     # the alternatives available within the maximum depth, token size and
     # decisions. Otherwise, if nothing is available (possibly due to some
@@ -117,7 +117,7 @@ class AlternationContext(object):
         return self._gen._model.choice(node, self._idx, self._weights)
 
 
-class QuantifierContext(object):
+class QuantifierContext:
 
     def __init__(self, gen, idx, min, max, min_size, reserve):
         self._gen = gen
@@ -153,7 +153,7 @@ class QuantifierContext(object):
         return False
 
 
-class Generator(object):
+class Generator:
     """
     Base class of the generated Generators. Stores the decision model, the listeners,
     and additional internal state used during generation.

--- a/grammarinator/runtime/listener.py
+++ b/grammarinator/runtime/listener.py
@@ -6,7 +6,7 @@
 # according to those terms.
 
 
-class Listener(object):
+class Listener:
     """
     Base class of listeners that get notified by generators whenever a rule is
     entered or exited. which needs to be subclassed.

--- a/grammarinator/runtime/model.py
+++ b/grammarinator/runtime/model.py
@@ -6,7 +6,7 @@
 # according to those terms.
 
 
-class Model(object):
+class Model:
     """
     Abstract base class of models that make decisions for generators at
     alternations, quantifiers, and charsets.

--- a/grammarinator/runtime/population.py
+++ b/grammarinator/runtime/population.py
@@ -5,7 +5,7 @@
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-class Population(object):
+class Population:
     """
     Base class of populations that store test cases in tree form (i.e.,
     individuals) and can select trees (and nodes in trees) for mutation or

--- a/grammarinator/runtime/rule.py
+++ b/grammarinator/runtime/rule.py
@@ -6,7 +6,7 @@
 # according to those terms.
 
 
-class RuleSize(object):
+class RuleSize:
 
     def __init__(self, depth=0, tokens=0):
         self.depth = depth
@@ -40,7 +40,7 @@ class RuleSize(object):
         return self.depth < other.depth and self.tokens < other.tokens
 
 
-class Rule(object):
+class Rule:
     """
     Base class of tree nodes.
     """

--- a/grammarinator/tool/default_population.py
+++ b/grammarinator/tool/default_population.py
@@ -20,7 +20,7 @@ from ..runtime import Population, RuleSize, UnparserRule
 logger = logging.getLogger(__name__)
 
 
-class DefaultTree(object):
+class DefaultTree:
 
     def __init__(self, root):
         """

--- a/grammarinator/tool/generator.py
+++ b/grammarinator/tool/generator.py
@@ -20,7 +20,7 @@ from ..runtime import CooldownModel, DefaultModel, RuleSize
 logger = logging.getLogger(__name__)
 
 
-class DefaultGeneratorFactory(object):
+class DefaultGeneratorFactory:
     """
     The default generator factory implementation. Instances of
     ``DefaultGeneratorFactory`` are callable. When called, a new generator
@@ -85,7 +85,7 @@ class DefaultGeneratorFactory(object):
         return generator
 
 
-class GeneratorTool(object):
+class GeneratorTool:
     """
     Class to create new test cases using the generator produced by ``grammarinator-process``.
     """

--- a/grammarinator/tool/parser.py
+++ b/grammarinator/tool/parser.py
@@ -31,7 +31,7 @@ class ConsoleListener(error.ErrorListener.ConsoleErrorListener):
 error.ErrorListener.ConsoleErrorListener.INSTANCE = ConsoleListener()
 
 
-class ParserTool(object):
+class ParserTool:
     """
     Class to parse existing sources and create a tree pool from them. These
     trees can be reused later by generation.

--- a/grammarinator/tool/processor.py
+++ b/grammarinator/tool/processor.py
@@ -29,7 +29,7 @@ from .g4 import ANTLRv4Lexer, ANTLRv4Parser
 logger = logging.getLogger(__name__)
 
 
-class Edge(object):
+class Edge:
 
     def __init__(self, dst, args=None):
         self.dst = dst
@@ -37,7 +37,7 @@ class Edge(object):
         self.reserve = 0
 
 
-class Node(object):
+class Node:
 
     _cnt = 0
 
@@ -73,7 +73,7 @@ class Node(object):
         return f'cls: {self.__class__.__name__}'
 
 
-class NodeSize(object):
+class NodeSize:
     def __init__(self, depth, tokens):
         self.depth = depth
         self.tokens = tokens
@@ -270,7 +270,7 @@ def multirange_diff(r1_list, r2_list):
     return r1_list
 
 
-class Charset(object):
+class Charset:
 
     dot = {
         'any_ascii_letter': [(ord('A'), ord('Z') + 1), (ord('a'), ord('z') + 1)],
@@ -291,7 +291,7 @@ class Charset(object):
         self.ranges = ranges
 
 
-class GrammarGraph(object):
+class GrammarGraph:
 
     def __init__(self):
         self.name = None
@@ -408,7 +408,7 @@ def escape_string(s):
     return ''.join(c for c in _iter_escaped_chars(s))
 
 
-class ProcessorTool(object):
+class ProcessorTool:
     """
     Class to process ANTLRv4 grammar files, build an internal representation
     from them and create a generator class that is able to produce textual data


### PR DESCRIPTION
In Python3, object is the implicit superclass. There is no need to explicitly define it.