### PR TITLE
Don't shadow builtin min and max in quantifier-related code

### DIFF
--- a/grammarinator/runtime/cooldown_model.py
+++ b/grammarinator/runtime/cooldown_model.py
@@ -51,11 +51,11 @@ class CooldownModel(Model):
                     self._weights[(node.name, idx, i)] = self._weights.get((node.name, idx, i), 1) / wsum
         return c
 
-    def quantify(self, node, idx, cnt, min, max):
+    def quantify(self, node, idx, cnt, start, stop):
         """
         Trampoline to the ``quantify`` method of the underlying model.
         """
-        return self._model.quantify(node, idx, cnt, min, max)
+        return self._model.quantify(node, idx, cnt, start, stop)
 
     def charset(self, node, idx, chars):
         """

--- a/grammarinator/runtime/default_model.py
+++ b/grammarinator/runtime/default_model.py
@@ -24,13 +24,14 @@ class DefaultModel(Model):
         # assert sum(weights) > 0, 'Sum of weights is zero.'
         return random.choices(range(len(weights)), weights=weights)[0]
 
-    def quantify(self, node, idx, cnt, min, max):
+    def quantify(self, node, idx, cnt, start, stop):
         """
-        After generating the minimum expected items (``min``) and before
-        reaching the maximum expected items (``max``), quantify decides about
+        After generating the minimum expected items (``start``) and before
+        reaching the maximum expected items (``stop``), quantify decides about
         the expansion of the optional items based on a random binary decision.
 
-        Parameters ``node``, ``idx``, ``cnt``, ``min`` and ``max`` are unused.
+        Parameters ``node``, ``idx``, ``cnt``, ``start``, and ``stop`` are
+        unused.
         """
         return bool(random.getrandbits(1))
 

--- a/grammarinator/runtime/dispatching_model.py
+++ b/grammarinator/runtime/dispatching_model.py
@@ -26,13 +26,13 @@ class DispatchingModel(DefaultModel):
         name = 'choice_' + node.name
         return (getattr(self, name) if hasattr(self, name) else super().choice)(node, idx, weights)
 
-    def quantify(self, node, idx, cnt, min, max):
+    def quantify(self, node, idx, cnt, start, stop):
         """
         Trampoline to the ``quantify_{node.name}`` method of the subclassed model, if it exists.
         Otherwise, it calls the default implementation (:meth:`DefaultModel.quantify`).
         """
         name = 'quantify_' + node.name
-        return (getattr(self, name) if hasattr(self, name) else super().quantify)(node, idx, cnt, min, max)
+        return (getattr(self, name) if hasattr(self, name) else super().quantify)(node, idx, cnt, start, stop)
 
     def charset(self, node, idx, chars):
         """

--- a/grammarinator/runtime/generator.py
+++ b/grammarinator/runtime/generator.py
@@ -119,12 +119,12 @@ class AlternationContext:
 
 class QuantifierContext:
 
-    def __init__(self, gen, idx, min, max, min_size, reserve):
+    def __init__(self, gen, idx, start, stop, min_size, reserve):
         self._gen = gen
         self._idx = idx
         self._cnt = 0
-        self._min = min
-        self._max = max
+        self._start = start
+        self._stop = stop
         self._min_size = min_size
         self._reserve = reserve
 
@@ -138,15 +138,15 @@ class QuantifierContext:
         self._gen._size.tokens -= self._reserve
 
     def __call__(self, node):
-        if self._cnt < self._min:
+        if self._cnt < self._start:
             self._cnt += 1
             return True
 
-        # Generate optional items if the current repeat count is between ``_min`` and ``_max`` and
+        # Generate optional items if the current repeat count is between ``_start`` and ``_stop`` and
         # if size limits allows the generation and if the current model decides so, too.
-        if (self._cnt < self._max
+        if (self._cnt < self._stop
                 and self._gen._size + self._min_size <= self._gen._limit
-                and self._gen._model.quantify(node, self._idx, self._cnt, self._min, self._max)):
+                and self._gen._model.quantify(node, self._idx, self._cnt, self._start, self._stop)):
             self._cnt += 1
             return True
 

--- a/grammarinator/runtime/model.py
+++ b/grammarinator/runtime/model.py
@@ -29,7 +29,7 @@ class Model:
         """
         raise NotImplementedError()
 
-    def quantify(self, node, idx, cnt, min, max):
+    def quantify(self, node, idx, cnt, start, stop):
         """
         Guide the loop of subtree quantification. This has to make a binary
         decision to tell whether to enable the next iteration or stop the loop.
@@ -41,9 +41,9 @@ class Model:
             quantified subtree.
         :param int idx: Index of the quantified subtree inside the current rule.
         :param int cnt: Number of the already generated subtrees, guaranteed
-            to be between ``min`` (inclusive) and ``max`` (exclusive).
-        :param int min: Lower bound of the quantification range.
-        :param int max: Upper bound of the quantification range.
+            to be between ``start`` (inclusive) and ``stop`` (exclusive).
+        :param int start: Lower bound of the quantification range.
+        :param int stop: Upper bound of the quantification range.
         :return: Boolean value enabling the next iteration or stopping it.
         :rtype: bool
         """

--- a/grammarinator/tool/processor.py
+++ b/grammarinator/tool/processor.py
@@ -203,16 +203,16 @@ class AlternativeNode(Node):
 
 class QuantifierNode(Node):
 
-    def __init__(self, rule_id, idx, min, max):
+    def __init__(self, rule_id, idx, start, stop):
         super().__init__()
         self.rule_id = rule_id  # Identifier of the container rule.
         self.idx = idx  # Index of the quantifier in the container rule.
-        self.min = min
-        self.max = max
+        self.start = start
+        self.stop = stop
         self.min_size = None
 
     def __str__(self):
-        return f'{super().__str__()}; idx: {self.idx}; min: {self.min}; max: {self.max}'
+        return f'{super().__str__()}; idx: {self.idx}; start: {self.start}; stop: {self.stop}'
 
 
 class ActionNode(Node):
@@ -342,7 +342,7 @@ class GrammarGraph:
             for ident, node in self.vertices.items():
                 children_sizes = [NodeSize(depth=min_sizes[out_node.id].depth + int(isinstance(out_node, RuleNode)),
                                            tokens=min_sizes[out_node.id].tokens + int(isinstance(out_node, UnlexerRuleNode)))
-                                  for out_node in node.out_neighbours if not isinstance(out_node, QuantifierNode) or out_node.min > 0]
+                                  for out_node in node.out_neighbours if not isinstance(out_node, QuantifierNode) or out_node.start > 0]
 
                 if isinstance(node, AlternationNode):
                     min_size = NodeSize(depth=min((c.depth for c in children_sizes), default=0),
@@ -372,7 +372,7 @@ class GrammarGraph:
             reserve = 0
             for edge in reversed(node.out_edges):
                 edge.reserve = reserve
-                if not isinstance(node, AlternationNode) and (not isinstance(edge.dst, QuantifierNode) or edge.dst.min > 0):
+                if not isinstance(node, AlternationNode) and (not isinstance(edge.dst, QuantifierNode) or edge.dst.start > 0):
                     reserve += min_sizes[edge.dst.id].tokens + int(isinstance(edge.dst, UnlexerRuleNode))
 
 
@@ -880,7 +880,7 @@ class ProcessorTool:
 
                     nonlocal quant_idx
                     suffix = str(suffix.children[0])
-                    quant_ranges = {'?': {'min': 0, 'max': 1}, '*': {'min': 0, 'max': 'inf'}, '+': {'min': 1, 'max': 'inf'}}
+                    quant_ranges = {'?': {'start': 0, 'stop': 1}, '*': {'start': 0, 'stop': 'inf'}, '+': {'start': 1, 'stop': 'inf'}}
                     quant_id = graph.add_node(QuantifierNode(rule_id=rule.id, idx=quant_idx, **quant_ranges[suffix]))
                     quant_idx += 1
                     graph.add_edge(frm=parent_id, to=quant_id)

--- a/grammarinator/tool/resources/codegen/GeneratorTemplate.py.jinja
+++ b/grammarinator/tool/resources/codegen/GeneratorTemplate.py.jinja
@@ -48,7 +48,7 @@ current.src += '{{ node.src | escape_string }}'
 
 
 {% macro processQuantifierNode(node, inedge) %}
-with QuantifierContext(self, {{ node.idx }}, {{ node.min }}, {{ node.max }}, RuleSize({{ node.min_size.depth }}, {{ node.min_size.tokens }}), {{ inedge.reserve }}) as quant{{ node.idx }}:
+with QuantifierContext(self, {{ node.idx }}, {{ node.start }}, {{ node.stop }}, RuleSize({{ node.min_size.depth }}, {{ node.min_size.tokens }}), {{ inedge.reserve }}) as quant{{ node.idx }}:
     while quant{{ node.idx }}(current):
     {% for edge in node.out_edges %}
         {{ processNode(edge.dst, edge) | indent | indent -}}

--- a/tests/grammars/DispatchingModel.g4
+++ b/tests/grammars/DispatchingModel.g4
@@ -28,7 +28,7 @@ class CustomModel(DispatchingModel):
         # Enforce choosing the third alternative (`c`).
         return 2
 
-    def quantify_start(self, node, idx, cnt, min, max):
+    def quantify_start(self, node, idx, cnt, start, stop):
         # Enforce to repeat 3 times.
         return cnt < 3
 


### PR DESCRIPTION
Both the tools (the processor, the codegen template) and the runtime (the models) contain code that deals with quantifiers. Quantification has lower and upper bounds, which are traditionally named min and max. However, having min and max as function arguments (like in models) shadows the Python builtins. To avoid this and make the builtins available, min is renamed to start while max is renamed to stop all around the code base (terminology borrowed from the range Python builtin).