### PR TITLE
Fix code generation for uninitialized locals and returns

### DIFF
--- a/grammarinator/tool/resources/codegen/GeneratorTemplate.py.jinja
+++ b/grammarinator/tool/resources/codegen/GeneratorTemplate.py.jinja
@@ -144,7 +144,7 @@ class {{ graph.name }}({{ graph.superclass }}):
     def {{ rule.id }}(self, {% for k, v in rule.args %}{{ k }}{% if v %}={{ resolveVarRefs(v) }}{% endif %}, {% endfor %}parent=None):
         {% if rule.id != 'EOF' %}
         {% if rule.labels or rule.args or rule.locals or rule.returns %}
-        local_ctx = {{ '{' }}{% for k, _ in rule.args %}'{{ k }}': {{ k }}{% if not loop.last %}, {% endif %}{% endfor %}{% if rule.args and (rule.locals + rule.returns) %}, {% endif %}{% for k, v in (rule.locals + rule.returns) %}'{{ k }}'{% if v %}: {{ resolveVarRefs(v) }}{% endif %}{% if not loop.last or rule.labels %}, {% endif %}{% endfor %}{% for name, is_list in rule.labels.items() %}'{{ name }}': {% if is_list %}[]{% else %}None{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}{{ '}' }}
+        local_ctx = {{ '{' }}{% for k, _ in rule.args %}'{{ k }}': {{ k }}{% if not loop.last %}, {% endif %}{% endfor %}{% if rule.args and (rule.locals + rule.returns) %}, {% endif %}{% for k, v in (rule.locals + rule.returns) %}'{{ k }}': {% if v %}{{ resolveVarRefs(v) }}{% else %}None{% endif %}{% if not loop.last or rule.labels %}, {% endif %}{% endfor %}{% for name, is_list in rule.labels.items() %}'{{ name }}': {% if is_list %}[]{% else %}None{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}{{ '}' }}
         {% endif %}
         with {{ rule.type }}Context(self, '{{ rule.id }}', parent) as current:
             {% for edge in rule.out_edges %}

--- a/tests/grammars/Locals.g4
+++ b/tests/grammars/Locals.g4
@@ -18,7 +18,7 @@
 
 grammar Locals;
 
-start locals[cnt=0]
+start locals[cnt=0, unused_and_uninitialized]
     : (Char {$cnt += 1})+ {assert(len(str(current)) == $cnt)}
     ;
 

--- a/tests/grammars/Returns.g4
+++ b/tests/grammars/Returns.g4
@@ -31,7 +31,7 @@ start
     : res=expr '==' v=VAR {$v.src = str($res.result); assert(eval(str($res))) == float(str($res.result));}
     ;
 
-expr returns [result=0]
+expr returns [result=0, unused_and_uninitialized]
     : '(' op1=expr op='*' op2=expr ')' {$result = exec_op($op1.result, str($op), $op2.result)}
     | '(' op1=expr op=('+' | '-') op2=expr ')' {$result = exec_op($op1.result, str($op), $op2.result)}
     | num=Number {$result = float(str($num))}


### PR DESCRIPTION
Even if locals or returns are not initialized in the grammar, the generated code must initialize them to None at least to be syntactically correct.