### PR TITLE
Do not add rule nodes to their parent during initialization

### DIFF
--- a/examples/fuzzer/HTMLCustomGenerator.py
+++ b/examples/fuzzer/HTMLCustomGenerator.py
@@ -32,7 +32,7 @@ class HTMLCustomGenerator(HTMLGenerator):
         with UnparserRuleContext(gen=self, name='htmlTagName', parent=parent) as current:
             name = random.choice(tags[self.tag_stack[-1]]['children'] or tag_names if self.tag_stack else tag_names)
             self.tag_stack.append(name)
-            UnlexerRule(src=name, parent=current)
+            current += UnlexerRule(src=name)
             self.tag_stack.append(name)
             return current
 
@@ -41,14 +41,14 @@ class HTMLCustomGenerator(HTMLGenerator):
         with UnparserRuleContext(gen=self, name='htmlAttributeName', parent=parent) as current:
             name = random.choice(list(tags[self.tag_stack[-1]]['attributes'].keys()) or ['""'])
             self.attr_stack.append(name)
-            UnlexerRule(src=name, parent=current)
+            current += UnlexerRule(src=name)
             return current
 
     # Customize the function generated from the htmlAttributeValue parser rule to produce valid attribute values
     # to the current tag and attribute name.
     def htmlAttributeValue(self, parent=None):
         with UnparserRuleContext(gen=self, name='htmlAttributeValue', parent=parent) as current:
-            UnlexerRule(src=random.choice(tags[self.tag_stack[-1]]['attributes'].get(self.attr_stack.pop(), ['""']) or ['""']), parent=current)
+            current += UnlexerRule(src=random.choice(tags[self.tag_stack[-1]]['attributes'].get(self.attr_stack.pop(), ['""']) or ['""']))
             return current
 
     def _endOfHtmlElement(self):

--- a/grammarinator/runtime/generator.py
+++ b/grammarinator/runtime/generator.py
@@ -39,9 +39,15 @@ class UnlexerRuleContext(RuleContext):
     # Subclass of :class:`RuleContext` handling unlexer rules.
 
     def __init__(self, gen, name, parent=None):
-        unlexer_parent = isinstance(parent, UnlexerRule)
-        super().__init__(gen, parent if unlexer_parent else UnlexerRule(name=name, parent=parent))
-        self._start_depth = None if unlexer_parent else self._gen._size.depth
+        if isinstance(parent, UnlexerRule):
+            super().__init__(gen, parent)
+            self._start_depth = None
+        else:
+            node = UnlexerRule(name=name)
+            if parent:
+                parent += node
+            super().__init__(gen, node)
+            self._start_depth = self._gen._size.depth
 
     def __enter__(self):
         node = super().__enter__()
@@ -64,7 +70,10 @@ class UnparserRuleContext(RuleContext):
     # Subclass of :class:`RuleContext` handling unparser rules.
 
     def __init__(self, gen, name, parent=None):
-        super().__init__(gen, UnparserRule(name=name, parent=parent))
+        node = UnparserRule(name=name)
+        if parent:
+            parent += node
+        super().__init__(gen, node)
 
 
 class AlternationContext:

--- a/grammarinator/runtime/rule.py
+++ b/grammarinator/runtime/rule.py
@@ -79,18 +79,15 @@ class Rule:
     Base class of tree nodes.
     """
 
-    def __init__(self, *, name, parent=None):
+    def __init__(self, *, name):
         """
         :param str name: Name of the node, i.e., name of the corresponding parser or lexer rule in the grammar.
-        :param UnparserRule parent: Parent node object (default: None).
 
         :ivar str name: Name of the node, i.e., name of the corresponding parser or lexer rule in the grammar.
         :ivar UnparserRule parent: Parent node object.
         """
         self.name = name
-        self.parent = parent
-        if parent:
-            parent += self
+        self.parent = None
 
     @property
     def left_sibling(self):
@@ -169,14 +166,13 @@ class UnparserRule(Rule):
     :class:`UnlexerRule` children.
     """
 
-    def __init__(self, name, parent=None):
+    def __init__(self, *, name):
         """
         :param str name: Name of the corresponding parser rule in the grammar.
-        :param UnparserRule parent: Parent node object (default: None).
 
         :ivar list[Rule] children: Children of the rule.
         """
-        super().__init__(name=name, parent=parent)
+        super().__init__(name=name)
         self.children = []
 
     @property
@@ -277,10 +273,9 @@ class UnlexerRule(Rule):
     Tree node representing a lexer rule or token. It has a string constant set in its ``src`` field.
     """
 
-    def __init__(self, *, name=None, parent=None, src=None):
+    def __init__(self, *, name=None, src=None):
         """
         :param str name: Name of the corresponding lexer rule in the grammar.
-        :param UnparserRule parent: Parent node object (default: None).
         :param str src: String content of the lexer rule (default: "").
 
         :ivar str src: String content of the lexer rule.
@@ -290,7 +285,7 @@ class UnlexerRule(Rule):
         self.src = src or ''
         self.size = RuleSize(depth=1 if src else 0, tokens=1 if src else 0)
 
-        super().__init__(name=name, parent=parent)
+        super().__init__(name=name)
 
     def __str__(self):
         """

--- a/grammarinator/tool/resources/codegen/GeneratorTemplate.py.jinja
+++ b/grammarinator/tool/resources/codegen/GeneratorTemplate.py.jinja
@@ -131,7 +131,8 @@ class {{ graph.name }}({{ graph.superclass }}):
 
     {% for rule in graph.imag_rules %}
     def {{ rule.id }}(self, parent=None):
-        return UnlexerRule(name='{{ rule.id }}', parent=parent)
+        with UnlexerRuleContext(self, '{{ rule.id }}', parent) as current:
+            return current
     {% endfor %}
 
     {%- if graph.members %}

--- a/tests/grammars/CustomSubclassGenerator.py
+++ b/tests/grammars/CustomSubclassGenerator.py
@@ -15,8 +15,8 @@ from CustomGenerator import CustomGenerator
 class CustomSubclassGenerator(CustomGenerator):
 
     def tagname(self, parent=None):
-        with UnparserRuleContext(gen=self, name='tagname', parent=parent) as current:
-            UnlexerRule(src='customtag', parent=current)
+        with UnparserRuleContext(self, 'tagname', parent) as current:
+            current += UnlexerRule(src='customtag')
             return current
 
     def _custom_lexer_content(self):

--- a/tests/grammars/ImagToken.g4
+++ b/tests/grammars/ImagToken.g4
@@ -19,7 +19,10 @@ grammar ImagToken;
 
 @lexer::members {
 def REDEFINED(self, parent=None):
-    return UnlexerRule(name='REDEFINED', src='redefined', parent=parent)
+    current = UnlexerRule(name='REDEFINED', src='redefined')
+    if parent:
+        parent += current
+    return current
 }
 
 tokens { IMAG, REDEFINED }

--- a/tests/grammars/SuperGenerator.py
+++ b/tests/grammars/SuperGenerator.py
@@ -13,4 +13,7 @@ from grammarinator.runtime import Generator, UnlexerRule
 class SuperGenerator(Generator):
 
     def inheritedRule(self, parent=None):
-        return UnlexerRule(src='I was inherited.', parent=parent)
+        current = UnlexerRule(src='I was inherited.')
+        if parent:
+            parent += current
+        return current


### PR DESCRIPTION
Callers, typically Contexts, can take this responsibility. This also ensures that by the time a child is added to its parent, the child object is already fully constructed.

Related minor fixes:
- Make UnparserRule init argument keyword-only to align it with Rule and UnlexerRule.
- Don't pass parameters by name when using RuleContexts in tests to align the usage with generated code.