### PR TITLE
Implement string formatting for tree nodes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -22,6 +22,7 @@ extension-pkg-allow-list=math
 disable=
     broad-except,
     comparison-with-callable,
+    consider-using-f-string,
     fixme,
     invalid-name,
     line-too-long,

--- a/docs/grammarinator.runtime.rst
+++ b/docs/grammarinator.runtime.rst
@@ -5,5 +5,5 @@ Runtime API: package ``grammarinator.runtime``
 .. automodule:: grammarinator.runtime
    :members:
    :imported-members:
-   :special-members: __call__, __enter__, __exit__, __iadd__, __str__
+   :special-members: __call__, __enter__, __exit__, __iadd__
    :show-inheritance:

--- a/grammarinator/tool/default_population.py
+++ b/grammarinator/tool/default_population.py
@@ -84,36 +84,6 @@ class DefaultTree:
         with open(fn, 'wb') as f:
             pickle.dump(self, f)
 
-    def print(self):
-        """
-        Print the structure of the tree (for debugging purposes).
-        """
-        def _walk(node):
-            nonlocal indent
-
-            if isinstance(node, UnparserRule):
-                print(f'{"|  " * indent}{node.name}')
-                indent += 1
-                for child in node.children:
-                    _walk(child)
-                indent -= 1
-
-            else:
-                print(f'{"|  " * indent}{node.name or ""}{":" if node.name else ""}{node.src!r}')
-
-        indent = 0
-        _walk(self.root)
-
-    def __str__(self):
-        """
-        Create the string representation of the tree starting from the
-        root node. Return a raw token sequence without any formatting.
-
-        :return: String representation of the tree.
-        :rtype: str
-        """
-        return str(self.root)
-
 
 class DefaultPopulation(Population):
     """


### PR DESCRIPTION
In addition to the classic "informal" (str) and "official" (repr) formats, a "debug" format is supported as well. Plus, the formatting logic is now in the related classes.