### PR TITLE
Add support for multiple tree file formats

### DIFF
--- a/grammarinator/cli.py
+++ b/grammarinator/cli.py
@@ -10,6 +10,8 @@ import os
 
 from inators.imp import import_object
 
+from .tool import JsonTreeCodec, PickleTreeCodec
+
 logger = logging.getLogger('grammarinator')
 
 
@@ -39,3 +41,20 @@ def add_encoding_argument(parser, help):
 def add_encoding_errors_argument(parser):
     parser.add_argument('--encoding-errors', metavar='NAME', default='strict',
                         help='encoding error handling scheme (default: %(default)s).')
+
+
+tree_formats = {
+    'pickle': {'extension': 'grtp', 'codec_class': PickleTreeCodec},
+    'json': {'extension': 'grtj', 'codec_class': JsonTreeCodec},
+}
+
+
+def add_tree_format_argument(parser):
+    parser.add_argument('--tree-format', metavar='NAME', choices=sorted(tree_formats.keys()), default='pickle',
+                        help='format of the saved trees (choices: %(choices)s, default: %(default)s)')
+
+
+def process_tree_format_argument(args):
+    tree_format = tree_formats[args.tree_format]
+    args.tree_extension = tree_format['extension']
+    args.tree_codec = tree_format['codec_class']()

--- a/grammarinator/generate.py
+++ b/grammarinator/generate.py
@@ -19,7 +19,7 @@ from os.path import abspath, exists, isdir, join
 from inators.arg import add_log_level_argument, add_sys_path_argument, add_sys_recursion_limit_argument, add_version_argument, process_log_level_argument, process_sys_path_argument, process_sys_recursion_limit_argument
 from inators.imp import import_object
 
-from .cli import add_encoding_argument, add_encoding_errors_argument, add_jobs_argument, import_list, init_logging, logger
+from .cli import add_encoding_argument, add_encoding_errors_argument, add_tree_format_argument, add_jobs_argument, import_list, init_logging, logger, process_tree_format_argument
 from .pkgdata import __version__
 from .runtime import RuleSize
 from .tool import DefaultGeneratorFactory, DefaultPopulation, GeneratorTool
@@ -69,8 +69,10 @@ def generator_tool_helper(args, weights, lock):
                          rule=args.rule, out_format=args.out,
                          limit=RuleSize(depth=args.max_depth, tokens=args.max_tokens),
                          population=DefaultPopulation(args.population,
+                                                      args.tree_extension,
                                                       min_sizes=args.generator._rule_sizes,
-                                                      immutable_rules=args.generator._immutable_rules) if args.population else None,
+                                                      immutable_rules=args.generator._immutable_rules,
+                                                      codec=args.tree_codec) if args.population else None,
                          generate=args.generate, mutate=args.mutate, recombine=args.recombine, keep_trees=args.keep_trees,
                          transformers=args.transformer, serializer=args.serializer,
                          cleanup=False, encoding=args.encoding, errors=args.encoding_errors, dry_run=args.dry_run)
@@ -122,6 +124,7 @@ def execute():
                         help='disable test generation by recombination (disabled by default if no population is given).')
     parser.add_argument('--keep-trees', default=False, action='store_true',
                         help='keep generated tests to participate in further mutations or recombinations (only if population is given).')
+    add_tree_format_argument(parser)
 
     # Auxiliary settings.
     parser.add_argument('-o', '--out', metavar='FILE', default=join(os.getcwd(), 'tests', 'test_%d'),
@@ -147,6 +150,7 @@ def execute():
     process_log_level_argument(args, logger)
     process_sys_path_argument(args)
     process_sys_recursion_limit_argument(args)
+    process_tree_format_argument(args)
     try:
         process_args(args)
     except ValueError as e:

--- a/grammarinator/parse.py
+++ b/grammarinator/parse.py
@@ -14,7 +14,7 @@ from os.path import exists, join
 from antlerinator import add_antlr_argument, process_antlr_argument
 from inators.arg import add_log_level_argument, add_sys_path_argument, add_sys_recursion_limit_argument, add_version_argument, process_log_level_argument, process_sys_path_argument, process_sys_recursion_limit_argument
 
-from .cli import add_disable_cleanup_argument, add_encoding_argument, add_encoding_errors_argument, add_jobs_argument, import_list, init_logging, logger
+from .cli import add_disable_cleanup_argument, add_encoding_argument, add_encoding_errors_argument, add_tree_format_argument, add_jobs_argument, import_list, init_logging, logger, process_tree_format_argument
 from .pkgdata import __version__
 from .runtime import RuleSize
 from .tool import DefaultPopulation, ParserTool
@@ -54,6 +54,7 @@ def execute():
                         help='directory to save the trees (default: %(default)s).')
     parser.add_argument('--parser-dir', metavar='DIR',
                         help='directory to save the parser grammars (default: <OUTDIR>/grammars).')
+    add_tree_format_argument(parser)
     add_encoding_argument(parser, help='input file encoding (default: %(default)s).')
     add_encoding_errors_argument(parser)
     add_disable_cleanup_argument(parser)
@@ -70,13 +71,14 @@ def execute():
     process_sys_path_argument(args)
     process_sys_recursion_limit_argument(args)
     process_antlr_argument(args)
+    process_tree_format_argument(args)
     try:
         process_args(args)
     except ValueError as e:
         parser.error(e)
 
     with ParserTool(grammars=args.grammar, hidden=args.hidden, transformers=args.transformer, parser_dir=args.parser_dir, antlr=args.antlr, rule=args.rule,
-                    population=DefaultPopulation(args.out), max_depth=args.max_depth, cleanup=args.cleanup, encoding=args.encoding, errors=args.encoding_errors) as parser:
+                    population=DefaultPopulation(args.out, args.tree_extension, codec=args.tree_codec), max_depth=args.max_depth, cleanup=args.cleanup, encoding=args.encoding, errors=args.encoding_errors) as parser:
         if args.jobs > 1:
             with Pool(args.jobs) as pool:
                 for _ in pool.imap_unordered(parser.parse, args.input):

--- a/grammarinator/tool/__init__.py
+++ b/grammarinator/tool/__init__.py
@@ -9,3 +9,4 @@ from .default_population import DefaultPopulation
 from .generator import DefaultGeneratorFactory, GeneratorTool
 from .parser import ParserTool
 from .processor import ProcessorTool
+from .tree_codec import AnnotatedTreeCodec, JsonTreeCodec, PickleTreeCodec, TreeCodec

--- a/grammarinator/tool/tree_codec.py
+++ b/grammarinator/tool/tree_codec.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2023 Renata Hodovan, Akos Kiss.
+#
+# Licensed under the BSD 3-Clause License
+# <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+# This file may not be copied, modified, or distributed except
+# according to those terms.
+
+import json
+import pickle
+
+from ..runtime import RuleSize, UnlexerRule, UnparserRule
+
+
+class TreeCodec:
+    """
+    Abstract base class of tree codecs that convert between trees and bytes.
+    """
+
+    def encode(self, root):
+        """
+        Encode a tree into an array of bytes.
+
+        Raises :exc:`NotImplementedError` by default.
+
+        :param ~grammarinator.runtime.Rule root: Root of the tree to be encoded.
+        :return: The encoded form of the tree.
+        :rtype: bytes
+        """
+        raise NotImplementedError()
+
+    def decode(self, data):
+        """
+        Decode a tree from an array of bytes.
+
+        Raises :exc:`NotImplementedError` by default.
+
+        :param bytes data: The encoded form of a tree.
+        :return: Root of the decoded tree.
+        :rtype: ~grammarinator.runtime.Rule
+        """
+        raise NotImplementedError()
+
+
+class AnnotatedTreeCodec(TreeCodec):
+    """
+    Abstract base class of tree codecs that can encode and decode extra data
+    (i.e., annotations) when converting between trees and bytes.
+    """
+
+    def encode(self, root):
+        """
+        Encode a tree without any annotations. Equivalent to calling
+        :meth:`encode_annotated` with ``annotations=None``.
+        """
+        return self.encode_annotated(root, None)
+
+    def encode_annotated(self, root, annotations):
+        """
+        Encode a tree and associated annotations into an array of bytes.
+
+        Raises :exc:`NotImplementedError` by default.
+
+        :param ~grammarinator.runtime.Rule root: Root of the tree to be encoded.
+        :param object annotations: Data to be encoded along the tree. No
+            assumption should be made about the structure or the contents of the
+            data, it should be treated as opaque.
+        :return: The encoded form of the tree and its annotations.
+        :rtype: bytes
+        """
+        raise NotImplementedError()
+
+    def decode(self, data):
+        """
+        Decode only the tree from an array of bytes without the associated
+        annotations. Equivalent to calling :meth:`decode_annotated` and keeping
+        only the first element of the returned tuple.
+        """
+        root, _ = self.decode_annotated(data)
+        return root
+
+    def decode_annotated(self, data):
+        """
+        Decode a tree and associated annotations from an array of bytes.
+
+        Raises :exc:`NotImplementedError` by default.
+
+        :param bytes data: The encoded form of a tree and its annotations.
+        :return: Root of the decoded tree, and the decoded annotations.
+        :rtype: tuple[~grammarinator.runtime.Rule,object]
+        """
+        raise NotImplementedError()
+
+
+class PickleTreeCodec(AnnotatedTreeCodec):
+    """
+    Tree codec based on Python's :mod:`pickle` module.
+    """
+
+    def encode_annotated(self, root, annotations):
+        return pickle.dumps((root, annotations))
+
+    def decode_annotated(self, data):
+        try:
+            root, annotations = pickle.loads(data)
+            return root, annotations
+        except pickle.UnpicklingError:
+            return None, None
+
+
+class JsonTreeCodec(TreeCodec):
+    """
+    JSON-based tree codec.
+    """
+
+    def __init__(self, encoding='utf-8'):
+        """
+        :param str encoding: The encoding to use when converting between
+            json-formatted text and bytes (default: utf-8).
+        """
+        self._encoding = encoding
+
+    def encode(self, root):
+        def _rule_to_dict(node):
+            if isinstance(node, UnlexerRule):
+                return {'n': node.name, 't': 'l', 's': node.src, 'z': [node.size.depth, node.size.tokens]}
+            if isinstance(node, UnparserRule):
+                return {'n': node.name, 't': 'p', 'c': node.children}
+            raise AssertionError
+        return json.dumps(root, default=_rule_to_dict).encode(encoding=self._encoding)
+
+    def decode(self, data):
+        def _dict_to_rule(dct):
+            if dct['t'] == 'l':
+                obj = UnlexerRule(name=dct['n'], src=dct['s'])
+                obj.size = RuleSize(depth=dct['z'][0], tokens=dct['z'][1])
+                return obj
+            if dct['t'] == 'p':
+                obj = UnparserRule(name=dct['n'])
+                for child in dct['c']:
+                    obj += child
+                return obj
+            raise json.JSONDecodeError
+
+        try:
+            return json.loads(data.decode(encoding=self._encoding), object_hook=_dict_to_rule)
+        except json.JSONDecodeError:
+            return None

--- a/tests/grammars/LifeCycle.g4
+++ b/tests/grammars/LifeCycle.g4
@@ -20,14 +20,20 @@
  *    - Next, create tests with recombination only and keep the output trees.
  *    - Third, use both mutation and recombination on the population extended
  *      with the previously generated trees.
+ * Population-related tasks (parsing, mutation, recombination) are checked using
+ * both available tree file formats.
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
 // TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -r start -n 3 -s grammarinator.runtime.simple_space_serializer -o {tmpdir}/{grammar}A%d.txt
-// TEST-PARSE: {grammar}.g4 -j 1 -i {tmpdir}/LifeCycleA0.txt {tmpdir}/LifeCycleA1.txt {tmpdir}/LifeCycleA2.txt -r start --hidden WS -o {tmpdir}/population/
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -r start -n 3 --population {tmpdir}/population/ -o {tmpdir}/{grammar}B%d.txt --keep-trees --no-generate --no-recombine
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -r start -n 3 --population {tmpdir}/population/ -o {tmpdir}/{grammar}C%d.txt --keep-trees --no-generate --no-mutate
-// TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 2 -r start -n 6 --population {tmpdir}/population/ -o {tmpdir}/{grammar}D%d.txt --no-generate
+// TEST-PARSE: {grammar}.g4 -j 1 -i {tmpdir}/LifeCycleA0.txt {tmpdir}/LifeCycleA1.txt {tmpdir}/LifeCycleA2.txt -r start --hidden WS -o {tmpdir}/population/p/ --tree-format pickle
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -r start -n 3 --population {tmpdir}/population/p/ --tree-format pickle -o {tmpdir}/{grammar}PB%d.txt --keep-trees --no-generate --no-recombine
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -r start -n 3 --population {tmpdir}/population/p/ --tree-format pickle -o {tmpdir}/{grammar}PC%d.txt --keep-trees --no-generate --no-mutate
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 2 -r start -n 6 --population {tmpdir}/population/p/ --tree-format pickle -o {tmpdir}/{grammar}PD%d.txt --no-generate
+// TEST-PARSE: {grammar}.g4 -j 1 -i {tmpdir}/LifeCycleA0.txt {tmpdir}/LifeCycleA1.txt {tmpdir}/LifeCycleA2.txt -r start --hidden WS -o {tmpdir}/population/j/ --tree-format json
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -r start -n 3 --population {tmpdir}/population/j/ --tree-format json -o {tmpdir}/{grammar}JB%d.txt --keep-trees --no-generate --no-recombine
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -r start -n 3 --population {tmpdir}/population/j/ --tree-format json -o {tmpdir}/{grammar}JC%d.txt --keep-trees --no-generate --no-mutate
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 2 -r start -n 6 --population {tmpdir}/population/j/ --tree-format json -o {tmpdir}/{grammar}JD%d.txt --no-generate
 
 grammar LifeCycle;
 


### PR DESCRIPTION
The now-added tree codec framework provides means to convert between trees and arrays of bytes. Moreover, enhanced codecs can also support the serialization and deserialization of additional data (called annotations). The default population implementation is updated to make use of the tree codec framework and make optimal use of the annotations if supported by the chosen codec.

At the moment, two tree codecs are supported: a json-based, with no support for annotations, and a pickle-based, with support for annotations.

Note: The internal format of the files read and written by the pickle-based tree codec are NOT backward compatible with the serialized trees created with previous versions.