### PR TITLE
Support types in rule attribute definitions (args, locals, returns)

### DIFF
--- a/grammarinator/tool/processor.py
+++ b/grammarinator/tool/processor.py
@@ -790,11 +790,28 @@ class ProcessorTool:
                 # for the `call` use case, where it will be handled as a value.
                 if use_case != 'call' and k is None:
                     k, v = v, None
+                t = None
+                if k:
+                    m = re.fullmatch(r'(\w+)\s*:([^:].*)', k)  # postfix type notation (name: type)
+                    if m:
+                        t, k = m.group(2, 1)
+                        t = t.strip()
+                    else:
+                        m = re.fullmatch(r'(.+)\s+(\w+)', k)  # prefix type notation (type name)
+                        if m:
+                            t, k = m.group(1, 2)
+                            t = t.strip()
+                        else:
+                            m = re.fullmatch(r'(\w+)', k)  # no-type notation (name)
+                            if not m:
+                                raise ValueError(f'unsupported type notation {k} in {use_case}')
+                if t == '':
+                    raise ValueError(f'type in {use_case} must not be empty')
                 if k == '':
                     raise ValueError(f'name in {use_case} must not be empty')
                 if v == '':
                     raise ValueError(f'value in {use_case} must not be empty')
-                args.append((k, v))
+                args.append((t, k, v))
 
             if node and node.argActionBlock():
                 src = ''.join(str(chr_arg) for chr_arg in node.argActionBlock().ARGUMENT_CONTENT()).strip()

--- a/grammarinator/tool/resources/codegen/GeneratorTemplate.py.jinja
+++ b/grammarinator/tool/resources/codegen/GeneratorTemplate.py.jinja
@@ -30,9 +30,9 @@ pass
 
 {% macro processRuleNode(node, inedge) %}
 {% if inedge.reserve != 0 %}
-self._reserve({{ inedge.reserve }}, self.{{ node.id }}, {% if inedge.args %}{% for k, v in inedge.args %}{% if k %}{{ k }}={% endif %}{{ resolveVarRefs(v) }}, {% endfor %}{% endif %}parent=current)
+self._reserve({{ inedge.reserve }}, self.{{ node.id }}, {% if inedge.args %}{% for _, k, v in inedge.args %}{% if k %}{{ k }}={% endif %}{{ resolveVarRefs(v) }}, {% endfor %}{% endif %}parent=current)
 {% else %}
-self.{{ node.id }}({% if inedge.args %}{% for k, v in inedge.args %}{% if k %}{{ k }}={% endif %}{{ resolveVarRefs(v) }}, {% endfor %}{% endif %}parent=current)
+self.{{ node.id }}({% if inedge.args %}{% for _, k, v in inedge.args %}{% if k %}{{ k }}={% endif %}{{ resolveVarRefs(v) }}, {% endfor %}{% endif %}parent=current)
 {% endif %}
 {% endmacro %}
 
@@ -140,16 +140,16 @@ class {{ graph.name }}({{ graph.superclass }}):
     {% endif %}
 
     {% for rule in graph.rules %}
-    def {{ rule.id }}(self, {% for k, v in rule.args %}{{ k }}{% if v %}={{ resolveVarRefs(v) }}{% endif %}, {% endfor %}parent=None):
+    def {{ rule.id }}(self, {% for t, k, v in rule.args %}{{ k }}{% if t %}:{{ t }}{% endif %}{% if v %}={{ resolveVarRefs(v) }}{% endif %}, {% endfor %}parent=None):
         {% if rule.id != 'EOF' %}
         {% if rule.labels or rule.args or rule.locals or rule.returns %}
-        local_ctx = {{ '{' }}{% for k, _ in rule.args %}'{{ k }}': {{ k }}{% if not loop.last %}, {% endif %}{% endfor %}{% if rule.args and (rule.locals + rule.returns) %}, {% endif %}{% for k, v in (rule.locals + rule.returns) %}'{{ k }}': {% if v %}{{ resolveVarRefs(v) }}{% else %}None{% endif %}{% if not loop.last or rule.labels %}, {% endif %}{% endfor %}{% for name, is_list in rule.labels.items() %}'{{ name }}': {% if is_list %}[]{% else %}None{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}{{ '}' }}
+        local_ctx = {{ '{' }}{% for _, k, _ in rule.args %}'{{ k }}': {{ k }}{% if not loop.last %}, {% endif %}{% endfor %}{% if rule.args and (rule.locals + rule.returns) %}, {% endif %}{% for _, k, v in (rule.locals + rule.returns) %}'{{ k }}': {% if v %}{{ resolveVarRefs(v) }}{% else %}None{% endif %}{% if not loop.last or rule.labels %}, {% endif %}{% endfor %}{% for name, is_list in rule.labels.items() %}'{{ name }}': {% if is_list %}[]{% else %}None{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}{{ '}' }}
         {% endif %}
         with {{ rule.type }}Context(self, '{{ rule.id }}', parent) as current:
             {% for edge in rule.out_edges %}
             {{ processNode(edge.dst, edge) | indent | indent | indent -}}
             {% endfor %}
-            {% for k, _ in rule.returns %}
+            {% for _, k, _ in rule.returns %}
             current.{{ k }} = local_ctx['{{ k }}']
             {% endfor %}
             return current

--- a/tests/grammars/ArgumentsInAlternations.g4
+++ b/tests/grammars/ArgumentsInAlternations.g4
@@ -10,7 +10,8 @@
 /*
  * This test checks whether parser rule arguments are propagated properly down
  * the tree, even in an alternation that seems to contain "simple" alternatives
- * only.
+ * only. Plus it checks the parsing of prefix and postfix type notation and
+ * no-type notation in arguments.
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
@@ -20,4 +21,4 @@ grammar ArgumentsInAlternations;
 
 start : a[1] | b[1, 1];
 a[x=0] : 'a' {assert $x == 1};
-b[x=0, y=0] : 'b' {assert $x == 1 and $y == 1};
+b[x:int=0, int y=0] : 'b' {assert $x == 1 and $y == 1};

--- a/tests/grammars/Locals.g4
+++ b/tests/grammars/Locals.g4
@@ -9,7 +9,7 @@
 
 /*
  * This test checks whether parser rule local variables are declared
- * and handled correctly.
+ * and handled correctly (even in the presence of type information).
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
@@ -18,7 +18,7 @@
 
 grammar Locals;
 
-start locals[cnt=0, unused_and_uninitialized]
+start locals[cnt=0, unused_and_uninitialized:int]
     : (Char {$cnt += 1})+ {assert(len(str(current)) == $cnt)}
     ;
 

--- a/tests/grammars/Returns.g4
+++ b/tests/grammars/Returns.g4
@@ -8,8 +8,8 @@
  */
 
 /*
- * This test checks whether parser rule returns are propagated
- * properly up in the tree.
+ * This test checks whether parser rule returns are propagated properly up in
+ * the tree. Plus it checks the parsing of type notation in returns.
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
@@ -31,7 +31,7 @@ start
     : res=expr '==' v=VAR {$v.src = str($res.result); assert(eval(str($res))) == float(str($res.result));}
     ;
 
-expr returns [result=0, unused_and_uninitialized]
+expr returns [result=0, int unused_and_uninitialized]
     : '(' op1=expr op='*' op2=expr ')' {$result = exec_op($op1.result, str($op), $op2.result)}
     | '(' op1=expr op=('+' | '-') op2=expr ')' {$result = exec_op($op1.result, str($op), $op2.result)}
     | num=Number {$result = float(str($num))}


### PR DESCRIPTION
Both prefix or postfix type notation are supported in addition to the already existing no-type notation. At the moment, types are only used (and meaningful) for args, where they become type hints in the generated python code.