### PR TITLE
Enable labeled alternatives to start their name with their rule name

### DIFF
--- a/grammarinator/tool/parser.py
+++ b/grammarinator/tool/parser.py
@@ -153,8 +153,8 @@ class ParserTool:
             parent_node = node
 
             # Check if the rule is a labeled alternative.
-            if not class_name.lower().startswith(rule_name.lower()):
-                alt_name = class_name[:-len('Context')] if class_name.endswith('Context') else class_name
+            if class_name.endswith('Context') and class_name.lower() != rule_name.lower() + 'context':
+                alt_name = class_name[:-len('Context')]
                 rule_name = f'{rule_name}_{alt_name[0].upper()}{alt_name[1:]}'
                 labeled_alt_node = UnparserRule(name=rule_name)
                 node += labeled_alt_node

--- a/tests/grammars/LabeledAlternatives.g4
+++ b/tests/grammars/LabeledAlternatives.g4
@@ -9,7 +9,8 @@
 
 /*
  * This test checks whether the labeled alternatives are handled correctly
- * (including the handling of variables within labeled alternatives).
+ * (including the handling of variables within labeled alternatives and
+ * labels starting with the name of the containing rule).
  *
  * Note:
  *  - Because this test generates multiple outputs files, it exercises both
@@ -28,6 +29,7 @@ grammar LabeledAlternatives;
 start
     : x=Hello World           # HelloAlternative
     | Grammarinator y=Rulez   # GrammarinatorAlternative
+    | Hello Grammarinator     # StartLastOption
     ;
 
 Hello : 'hello' ;


### PR DESCRIPTION
In ANTLR, there is no such restriction on the name of a labeled alternative that it cannot start with the name of its container rule. The only restriction is that it cannot match completly with any rule name. The patch removes such a mistaken restriction from the Grammarinator parse implementation.