### PR TITLE
Rule API revision

### DIFF
--- a/grammarinator/tool/tree_codec.py
+++ b/grammarinator/tool/tree_codec.py
@@ -131,14 +131,9 @@ class JsonTreeCodec(TreeCodec):
     def decode(self, data):
         def _dict_to_rule(dct):
             if dct['t'] == 'l':
-                obj = UnlexerRule(name=dct['n'], src=dct['s'])
-                obj.size = RuleSize(depth=dct['z'][0], tokens=dct['z'][1])
-                return obj
+                return UnlexerRule(name=dct['n'], src=dct['s'], size=RuleSize(depth=dct['z'][0], tokens=dct['z'][1]))
             if dct['t'] == 'p':
-                obj = UnparserRule(name=dct['n'])
-                for child in dct['c']:
-                    obj += child
-                return obj
+                return UnparserRule(name=dct['n'], children=dct['c'])
             raise json.JSONDecodeError
 
         try:


### PR DESCRIPTION
- `Rule.left_sibling` and `Rule.right_sibling` had misleading documentation stating that "no parent" or "inconsistent state" raised `ValueError`. However, "no parent" raised a different kind of error, while "inconsistent state" was explicitly hidden by the implementation. Fixed "no parent" not to raise, but "inconsistent state" to do raise and error.

- `Rule.replace`, `UnparserRule.insert_child`, and `UnparserRule.add_child` did not ensure that the node to be added to the tree was removed from its parent (if it had any). Fixed to remove the added node from its original parent.

- `Rule.delete` got renamed to `Rule.remove` to better describe its functionality (the node is not deleted, only removed from its parent).

- `UnparserRule.last_child` property setter was removed, since `UnparserRule.last_child = ...` was equivalent to `UnparserRule.last_child.replace(...)` (actually, a bit even worse). Even the examples and tests used the latter approach.

- UnparserRule's and UnlexerRule's initializers got new arguments to enable the explicit setting of all fields (UnparserRule.children, UnlexerRule.size).

- JsonTreeCodec updated to make use of the new initializer arguments.

- `copy.deepcopy` of any node copied the whole tree as it walked along the parent chain by default. Added `__copy__` and `__deepcopy__` to nodes to explicitly control copying. Shallow copies are disabled, deep copies only copy subtrees (without copying ancestors as well).