### PR TITLE
Fix tree printing of alternations in the processor

### DIFF
--- a/grammarinator/tool/processor.py
+++ b/grammarinator/tool/processor.py
@@ -192,7 +192,7 @@ class AlternationNode(Node):
         return simple_lits, simple_rules
 
     def __str__(self):
-        return f'{super().__str__()}; idx: {self.idx}; cond: {", ".join(self.conditions)}'
+        return f'{super().__str__()}; idx: {self.idx}; conditions: {self.conditions}'
 
 
 class AlternativeNode(Node):


### PR DESCRIPTION
Alternation condition values can be stored as a list or as an identifier referring to an entry of the graphs appropriate container. However, the __str__ method of AlternationNode handled this incorrectly. This is fixed now.