### PR TITLE
Add GeneratorFactory base class

### DIFF
--- a/grammarinator/tool/__init__.py
+++ b/grammarinator/tool/__init__.py
@@ -6,7 +6,7 @@
 # according to those terms.
 
 from .default_population import DefaultPopulation
-from .generator import DefaultGeneratorFactory, GeneratorTool
+from .generator import DefaultGeneratorFactory, GeneratorFactory, GeneratorTool
 from .parser import ParserTool
 from .processor import ProcessorTool
 from .tree_codec import AnnotatedTreeCodec, JsonTreeCodec, PickleTreeCodec, TreeCodec


### PR DESCRIPTION
Removes the burden of exposing generator class variables from factory implementations. Should the list or names of variables to be exposed change in the future, this base class will be kept in sync with such changes and so factories subclassing this base class will not need to change their code.