### PR TITLE
Support rule labels with recurring names

### DIFF
--- a/grammarinator/tool/resources/codegen/GeneratorTemplate.py.jinja
+++ b/grammarinator/tool/resources/codegen/GeneratorTemplate.py.jinja
@@ -145,7 +145,7 @@ class {{ graph.name }}({{ graph.superclass }}):
         {% if rule.labels or rule.args or rule.locals or rule.returns %}
         local_ctx = {{ '{' }}{% for _, k, _ in rule.args %}'{{ k }}': {{ k }}{% if not loop.last %}, {% endif %}{% endfor %}{% if rule.args and (rule.locals + rule.returns) %}, {% endif %}{% for _, k, v in (rule.locals + rule.returns) %}'{{ k }}': {% if v %}{{ resolveVarRefs(v) }}{% else %}None{% endif %}{% if not loop.last or rule.labels %}, {% endif %}{% endfor %}{% for name, is_list in rule.labels.items() %}'{{ name }}': {% if is_list %}[]{% else %}None{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}{{ '}' }}
         {% endif %}
-        with {{ rule.type }}Context(self, '{{ rule.id }}', parent) as current:
+        with {{ rule.type }}Context(self, '{{ rule.name }}', parent) as current:
             {% for edge in rule.out_edges %}
             {{ processNode(edge.dst, edge) | indent | indent | indent -}}
             {% endfor %}

--- a/tests/grammars/LifeCycle.g4
+++ b/tests/grammars/LifeCycle.g4
@@ -40,14 +40,18 @@ grammar LifeCycle;
 start : TEST testType ;
 
 testType
-     : PROCESS   # ProcessType
-     | GENERATE  # GenerateType
-     | PARSE     # ParseType
+     : PROCESS    # ProcessType
+     | GENERATE   # GenerateType
+     | MUTATE     # GenerateType
+     | RECOMBINE  # GenerateType
+     | PARSE      # ParseType
      ;
 
 TEST : 'TEST' ;
 PROCESS : 'PROCESS' ;
 GENERATE : 'GENERATE' ;
+MUTATE : 'MUTATE' ;
+RECOMBINE : 'RECOMBINE' ;
 PARSE : 'PARSE' ;
 
 WS : [ \t\n\r] -> channel(HIDDEN);


### PR DESCRIPTION
The new approach produces postfixed methods from alternatives with recurring names. These methods create rule nodes without postfixes just like before. To make possible to regenerate these rules during mutation, a further generator method was added without postfix - to match the name of the created rules. It groups together all the alternatives with common labels and makes possible to regenerate the nodes of the common labels.