### PR TITLE
Fix leftover path problems

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-exclude grammarinator/parser/ANTLRv4*.py
+exclude grammarinator/tool/g4/ANTLRv4*.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,9 @@ install_requires =
     jinja2
     regex
 
+[options.packages.find]
+exclude = tests
+
 [options.entry_points]
 console_scripts =
     grammarinator-process = grammarinator.process:execute


### PR DESCRIPTION
- When tool API got split from CLI, MANTIFEST.in was not updated to exclude the right files.
- When test folder got changed into a package, setup.cfg was not updated to exclude the new package from the distribution.

Fixes #209