### PR TITLE
Extend the input formats recognized by grammarinator-parse

### DIFF
--- a/docs/guide/population.rst
+++ b/docs/guide/population.rst
@@ -30,8 +30,10 @@ variations and explore different test cases.
    :replace: "parse.py/grammarinator-parse"
 
 The usage of the ``grammarinator-parse`` utility is generally straightforward.
-It takes a set of inputs (``--input``) and processes them with the specified
-grammars (``FILE``). The start rule, which determines the root of every tree
+It takes a set of inputs and processes them with the specified grammars
+(``FILE``). Inputs can be listed as files or directories (using ``--input``), or
+specified with file patterns (using ``--glob``). The listed directories are
+traversed recursively. The start rule, which determines the root of every tree
 in the population, can be defined using the ``--rule`` argument. After the
 parsing is completed and the tree is created, various
 :doc:`transformers <transformers>` (``--transformer``) can be applied to

--- a/grammarinator/cli.py
+++ b/grammarinator/cli.py
@@ -5,6 +5,7 @@
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
+import glob
 import logging
 import os
 
@@ -59,3 +60,16 @@ def process_tree_format_argument(args):
     tree_format = tree_formats[args.tree_format]
     args.tree_extension = tree_format['extension']
     args.tree_codec = tree_format['codec_class']()
+
+
+def iter_files(args):
+    for fn in args.input or []:
+        if os.path.isdir(fn):
+            for dirpath, _, filenames in os.walk(fn):
+                for f in filenames:
+                    yield os.path.join(dirpath, f)
+        else:
+            yield fn
+
+    for pattern in args.glob or []:
+        yield from glob.glob(pattern)


### PR DESCRIPTION
Until now, grammarinator-parse expected to receive a list of files as inputs to be processed. From now on, it also accepts directories, which will be recursively traversed. Furthermore, file patterns are also supported to easily filter and parse tests by patterns.