### PR TITLE
Ensure that listener sees correct name when lexer rule refers to another lexer rule

### DIFF
--- a/tests/grammars/Fragment.g4
+++ b/tests/grammars/Fragment.g4
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Renata Hodovan, Akos Kiss.
+ *
+ * Licensed under the BSD 3-Clause License
+ * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+ * This file may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+
+/*
+ * This test checks whether listeners see the correct names when lexer rules
+ * refer to other lexer rules (usually, fragment rules).
+ */
+
+// TEST-PROCESS: {grammar}.g4 -o {tmpdir}
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -n 1 --listener {grammar}Generator.CustomListener -o {tmpdir}/{grammar}%d.txt
+
+grammar Fragment;
+
+@header {
+
+from collections import Counter
+from grammarinator.runtime import Listener
+
+
+class CustomListener(Listener):
+
+    def __init__(self):
+        self.cnt_enters = Counter()
+        self.cnt_exits = Counter()
+
+    def enter_rule(self, node):
+        self.cnt_enters[node.name] += 1
+
+    def exit_rule(self, node):
+        self.cnt_exits[node.name] += 1
+        if node.name == 'start':
+            assert self.cnt_enters == Counter(start=1, A=1, B=1, C=1, D=1, E=1), self.cnt_enters
+            assert self.cnt_exits == Counter(start=1, A=1, B=1, C=1, D=1, E=1), self.cnt_exits
+}
+
+
+start : A;
+A : 'a' B ;
+B : 'b' C ;
+fragment C : 'c' D ;
+fragment D : 'd' E ;
+E : 'e' ;


### PR DESCRIPTION
Since token sub-rules (e.g., fragments) are not represented by unique nodes in the tree, even though listeners are called when the generation of a sub-rule starts or ends, the listeners only see the top-level token node and the name of the top-level lexer rule.

This commit changes this by faking the top-level token node to have the name of the sub-rule rule while generating the sub-rule.