### PR TITLE
Properly indent multi-line init and after actions

### DIFF
--- a/grammarinator/tool/resources/codegen/GeneratorTemplate.py.jinja
+++ b/grammarinator/tool/resources/codegen/GeneratorTemplate.py.jinja
@@ -162,13 +162,13 @@ class {{ graph.name }}({{ graph.superclass }}):
         with {{ rule.type }}Context(self, '{{ rule.name }}', parent) as rule:
             current = rule.current
             {% if rule.init %}
-            {{ resolveVarRefs(rule.init) }}
+            {{ resolveVarRefs(rule.init) | indent | indent | indent }}
             {% endif %}
             {% for edge in rule.out_edges %}
             {{ processNode(edge.dst, edge) | indent | indent | indent -}}
             {% endfor %}
             {% if rule.after %}
-            {{ resolveVarRefs(rule.after) }}
+            {{ resolveVarRefs(rule.after) | indent | indent | indent }}
             {% endif %}
             {% for _, k, _ in rule.returns %}
             current.{{ k }} = local_ctx['{{ k }}']

--- a/tests/grammars/InitAfter.g4
+++ b/tests/grammars/InitAfter.g4
@@ -22,9 +22,11 @@ start : r=wrapped_rule {assert $r.testValue == 'endValue', $r.testValue} ;
 wrapped_rule returns [testValue]
 @init {
 $testValue = 'startValue'
+pass  # no-op, only to ensure that multi-line actions are properly handled
 }
 @after {
 $testValue = 'endValue'
+pass  # no-op, only to ensure that multi-line actions are properly handled
 }
 : {assert $testValue == 'startValue', $testValue} A ;
 A : 'a' ;


### PR DESCRIPTION
Previously, only the first line got indented in the generated code, making it hard to write multi-line actions.