### PR TITLE
Fix the trampoline functions of recurring labeled alternatives

### DIFF
--- a/grammarinator/tool/processor.py
+++ b/grammarinator/tool/processor.py
@@ -87,12 +87,13 @@ class NodeSize:
 
 class RuleNode(Node):
 
-    def __init__(self, name, type):
+    def __init__(self, name, type, trampoline=False):
         name = name if isinstance(name, tuple) else (name,)
         super().__init__(name)
         # Keep rule and label name, but exclude label index if exists.
         self.name = '_'.join(part for part in name[:2])
         self.type = type
+        self.trampoline = trampoline
         self.min_size = None
 
         self.labels = {}
@@ -120,8 +121,8 @@ class UnlexerRuleNode(RuleNode):
 
 class UnparserRuleNode(RuleNode):
 
-    def __init__(self, name):
-        super().__init__(name, 'UnparserRule')
+    def __init__(self, name, trampoline=False):
+        super().__init__(name, 'UnparserRule', trampoline)
 
 
 class ImagRuleNode(Node):
@@ -933,7 +934,7 @@ class ProcessorTool:
                     for label in recurring_labels:
                         # Mask conditions to enable only the alternatives with the common label.
                         new_conditions = [cond if labels[ci] == label else '0' for ci, cond in enumerate(conditions)]
-                        recurring_rule_id = graph.add_node(UnparserRuleNode(name=(rule.name, label)))
+                        recurring_rule_id = graph.add_node(UnparserRuleNode(name=(rule.name, label), trampoline=True))
                         labeled_alt_id = graph.add_node(AlternationNode(idx=0,
                                                                         conditions=append_unique(graph.alt_conds, new_conditions) if all(isfloat(cond) for cond in new_conditions) else new_conditions,
                                                                         rule_id=recurring_rule_id))

--- a/grammarinator/tool/resources/codegen/GeneratorTemplate.py.jinja
+++ b/grammarinator/tool/resources/codegen/GeneratorTemplate.py.jinja
@@ -159,7 +159,7 @@ class {{ graph.name }}({{ graph.superclass }}):
             {% endfor -%}
         }
         {% endif %}
-        with {{ rule.type }}Context(self, '{{ rule.name }}', parent) as rule:
+        with {{ rule.type }}Context(self, {% if rule.trampoline %}'{{ rule.id[0] }}'{% else %}'{{ rule.name }}'{% endif %}, parent) as rule:
             current = rule.current
             {% if rule.init %}
             {{ resolveVarRefs(rule.init) | indent | indent | indent }}
@@ -173,7 +173,14 @@ class {{ graph.name }}({{ graph.superclass }}):
             {% for _, k, _ in rule.returns %}
             current.{{ k }} = local_ctx['{{ k }}']
             {% endfor %}
-            return current
+        {% if rule.trampoline %}
+        current.remove()
+        current = current.children[0].children[0]
+        current.remove()
+        if parent:
+            parent += current
+        {% endif %}
+        return current
 
     {% endfor %}
 

--- a/tests/grammars/RecurringLabelTrampolines.g4
+++ b/tests/grammars/RecurringLabelTrampolines.g4
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024 Renata Hodovan, Akos Kiss.
+ *
+ * Licensed under the BSD 3-Clause License
+ * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+ * This file may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+
+/*
+ * This test checks whether the trampoline functions of recurring labeled
+ * alternatives create the correct tree structure.
+ */
+
+// TEST-PROCESS: {grammar}.g4 -o {tmpdir}
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -m {grammar}Generator.CustomModel -j 1 -n 5 -o {tmpdir}/{grammar}%d.txt
+
+grammar RecurringLabelTrampolines;
+
+@header {
+from grammarinator.runtime import DispatchingModel
+
+class CustomModel(DispatchingModel):
+
+    def __init__(self):
+        self.alt = 1
+
+    def choice_start(self, node, idx, weights):
+        self.alt = 1 - self.alt
+        return self.alt
+
+}
+
+start
+@after {
+assert current.name == 'start', current.name
+assert isinstance(current.last_child, UnparserRuleAlternative), repr(current.last_child)
+assert len(current.last_child.children) == 1, current.last_child.children
+assert current.last_child.last_child.name == 'start_Foo', repr(current.last_child.last_child)
+assert current.last_child.last_child.last_child.name == 'Bar', repr(current.last_child.last_child.last_child)
+assert str(current) == 'bar', str(current)
+
+current.last_child.last_child.replace(self.start_Foo())
+
+assert current.name == 'start', current.name
+assert isinstance(current.last_child, UnparserRuleAlternative), repr(current.last_child)
+assert len(current.last_child.children) == 1, current.last_child.children
+assert current.last_child.last_child.name == 'start_Foo', repr(current.last_child.last_child)
+assert current.last_child.last_child.last_child.name == 'Baz', repr(current.last_child.last_child.last_child)
+assert str(current) == 'baz', str(current)
+}
+    : Bar # Foo
+    | Baz # Foo
+    ;
+
+Bar : 'bar' ;
+Baz : 'baz' ;


### PR DESCRIPTION
These trampoline functions are normally only used in mutation scenarios when a subtree of a labeled alternative is re-generated by calling the function named as the labeled alternative. If the label is recurring, this function is an artificial trampoline that calls one of the functions that have the same name prefix but differ in a numbered suffix (e.g., `rule_Label` calls `rule_Label_1` or `rule_Label_2`). The trampoline function is expected to be transparent, i.e., to create a tree structure as if one of the number-suffixed functions was called.

However, until now, the tree structures created by the trampolines and the way the trees were created were incorrect. The trampoline created two extra nodes in the tree: one UnparserRule node named as the labeled alternative (e.g., `rule_Lable`) and one UnparserRuleAlternative node.

- Issue 1: Both nodes are superfluous in the end result.
- Issue 2: Both nodes are necessary to help the decision model choose between the number-suffixed functions. But then, the UnparserRule should be named as the main rule that contains the labeled alternatives (e.g., `rule`).

This commit fixes both issues.