### PR TITLE
Disable testing Py3.10 on Ubuntu on GH Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.8, 3.9, '3.10', '3.11', '3.12', 'pypy-3.10']
+        exclude:
+          # NOTE: python/cpython#71936
+          - os: ubuntu-latest
+            python-version: '3.10'
     runs-on: ${{ matrix.os }}
     steps:
       - run: git config --global core.autocrlf input


### PR DESCRIPTION
A race condition in multiprocessing.Pool started causing problems on GH Actions. The issue never appears when testing locally. Disabling Py3.10/Ubuntu tests because they cause most of the failures.