### PR TITLE
Re-enable testing Py3.10 on Ubuntu on GH Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13', 'pypy-3.10']
-        exclude:
-          # NOTE: python/cpython#71936
-          - os: ubuntu-latest
-            python-version: '3.10'
     runs-on: ${{ matrix.os }}
     steps:
       - run: git config --global core.autocrlf input


### PR DESCRIPTION
With cooldown factor retired and shared weight dictionaries gone, the errors are (should be) gone as well.