### PR TITLE
Add grammar-violating mutations to the Generator

### DIFF
--- a/grammarinator/generate.py
+++ b/grammarinator/generate.py
@@ -62,7 +62,7 @@ def generator_tool_helper(args, weights, lock):
                          rule=args.rule, out_format=args.out, lock=lock,
                          limit=RuleSize(depth=args.max_depth, tokens=args.max_tokens),
                          population=DefaultPopulation(args.population, args.tree_extension, args.tree_codec) if args.population else None,
-                         generate=args.generate, mutate=args.mutate, recombine=args.recombine, keep_trees=args.keep_trees,
+                         generate=args.generate, mutate=args.mutate, recombine=args.recombine, unrestricted=args.unrestricted, keep_trees=args.keep_trees,
                          transformers=args.transformer, serializer=args.serializer,
                          cleanup=False, encoding=args.encoding, errors=args.encoding_errors, dry_run=args.dry_run)
 
@@ -108,6 +108,8 @@ def execute():
                         help='disable test generation by mutation (disabled by default if no population is given).')
     parser.add_argument('--no-recombine', dest='recombine', default=True, action='store_false',
                         help='disable test generation by recombination (disabled by default if no population is given).')
+    parser.add_argument('--no-grammar-violations', dest='unrestricted', default=True, action='store_false',
+                        help='disable applying grammar-violating mutators (enabled by default)')
     parser.add_argument('--keep-trees', default=False, action='store_true',
                         help='keep generated tests to participate in further mutations or recombinations (only if population is given).')
     add_tree_format_argument(parser)

--- a/grammarinator/runtime/rule.py
+++ b/grammarinator/runtime/rule.py
@@ -9,6 +9,8 @@ from copy import deepcopy
 from math import inf
 from textwrap import indent
 
+from itertools import zip_longest
+
 
 class RuleSize:
     """
@@ -218,6 +220,25 @@ class Rule:
         """
         return self.__class__ == other.__class__ and self.name == other.name
 
+    def equalTokens(self, other):
+        """
+        Compare the tokens in the sub-trees of two nodes.
+
+        :param Rule other: The node to compare the current node to.
+        :return: Whether the two nodes are equal.
+        :rtype: bool
+        """
+        return all(self_token == other_token for self_token, other_token in zip_longest(self.tokens(), other.tokens()))
+
+    def tokens(self):
+        """
+        Generator method to iterate over the (non-empty) tokens (i.e., strings) of the sub-tree of the node.
+
+        :return: Iterator over token string contents.
+        :rtype: iterator[str]
+        """
+        raise NotImplementedError()
+
     def _dbg_(self):
         """
         Called by :meth:`__format__` to compute the "debug" string
@@ -318,6 +339,10 @@ class ParentRule(Rule):
     def equals(self, other):
         return super().equals(other) and len(self.children) == len(other.children) and all(child.equals(other.children[i]) for i, child in enumerate(self.children))
 
+    def tokens(self):
+        for child in self.children:
+            yield from child.tokens()
+
     def __str__(self):
         return ''.join(str(child) for child in self.children)
 
@@ -390,6 +415,10 @@ class UnlexerRule(Rule):
 
     def equals(self, other):
         return super().equals(other) and self.src == other.src
+
+    def tokens(self):
+        if self.src:
+            yield self.src
 
     def __str__(self):
         return self.src


### PR DESCRIPTION
With a runtime flag, we can enable from now to apply grammar violating mutations on the trees. In this first commit, unrestricted node deletion and node hoisting are implemented.