### PR TITLE
Simplify simple_space_serializer using `tokens()` method

### DIFF
--- a/grammarinator/runtime/serializer.py
+++ b/grammarinator/runtime/serializer.py
@@ -1,11 +1,9 @@
-# Copyright (c) 2017-2023 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2024 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
 # This file may not be copied, modified, or distributed except
 # according to those terms.
-
-from .rule import ParentRule
 
 
 def simple_space_serializer(root):
@@ -17,14 +15,4 @@ def simple_space_serializer(root):
     :return: The serialized tree as string.
     :rtype: str
     """
-
-    def _tokens():
-        stack = [root]
-        while stack:
-            node = stack.pop()
-            if isinstance(node, ParentRule):
-                stack.extend(reversed(node.children))
-            else:
-                yield node.src
-
-    return ' '.join(token for token in _tokens())
+    return ' '.join(root.tokens())


### PR DESCRIPTION
The new `tokens()` method of rule nodes makes it easier to access their leaf node sequences. This update leverages the `tokens()` method to simplify the implementation of `simple_space_serializer`.