### PR TITLE
Improve the `replicate_quantified`

### DIFF
--- a/grammarinator/tool/generator.py
+++ b/grammarinator/tool/generator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2024 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2025 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -528,10 +528,12 @@ class GeneratorTool:
         root_options = [node for node in annot.quants if node.stop > len(node.children)]
         recipient_root_token_counts = annot.token_counts[root]
         node_options = [child for root in root_options for child in root.children if
-                        recipient_root_token_counts + annot.token_counts[child] <= self._limit.tokens]
+                        recipient_root_token_counts < recipient_root_token_counts + annot.token_counts[child] <= self._limit.tokens]
         if node_options:
             node_to_repeat = random.choice(node_options)
-            node_to_repeat.parent.insert_child(idx=random.randint(0, len(node_to_repeat.parent.children)), node=deepcopy(node_to_repeat))
+            max_repeat = (self._limit.tokens - recipient_root_token_counts) // annot.token_counts[node_to_repeat]
+            for _ in range(random.randint(1, max_repeat)):
+                node_to_repeat.parent.insert_child(idx=random.randint(0, len(node_to_repeat.parent.children)), node=deepcopy(node_to_repeat))
 
         # Return with the original root, whether the replication was successful or not.
         return root


### PR DESCRIPTION
The mutator is improved by ensuring to replicate non-empty subtrees only and instead of inserting a single copy, a random number of replicant will be added that still obeys the quantifier restrictions.