### PR TITLE
Fix user guide about models

### DIFF
--- a/docs/guide/models.rst
+++ b/docs/guide/models.rst
@@ -42,11 +42,11 @@ models are:
 
        grammar Primitives;
 
-       primitive : string | (decimal | float) | bool ;
-       string : [a-zA-Z] ;
-       decimal : [0-9]+;
-       float : '0'? '.' [0-9]+ ;
-       bool : 'true' | 'false' ;
+       primitive : String | (Decimal | Float) | Bool ;
+       String : [a-zA-Z] ;
+       Decimal : [0-9]+;
+       Float : '0'? '.' [0-9]+ ;
+       Bool : 'true' | 'false' ;
 
     .. code-block:: python
        :caption: Example subclassing of DefaultModel
@@ -60,20 +60,17 @@ models are:
                    weights[1] *= 5
                return super().choice(node, idx, weights)
 
-          def quantify(self, node, idx, min, max):
-              if node.name == 'float' and idx == 1:
-                  # Generate floats with two decimal digits at least.
-                  min = 2
-              yield from super().quantify(node, idx, min, max)
+           def quantify(self, node, idx, cnt, start, stop):
+               if node.name == 'Float' and idx == 1:
+                   # Generate floats with two decimal digits at least.
+                   start = 2
+               return super().quantify(node, idx, cnt, start, stop)
 
-          def charset(self, node, idx, chars):
-              # Ensure not choosing `0` as the first digit of a decimal.
-              if node.name == 'decimal' and len(node.children) == 0:
-                  non_zero_chars = chars[:]
-                  non_zero_chars.remove('0')
-                  return super().charset(node, idx, non_zero_chars)
-              return super().charset(node, idx, chars)
-
+           def charset(self, node, idx, chars):
+               # Ensure not choosing `0` as the first digit of a decimal.
+               if node.name == 'Decimal' and len(node.src) == 0:
+                   chars = tuple(c for c in chars if c != '0')
+               return super().charset(node, idx, chars)
 
   2. :class:`grammarinator.runtime.DispatchingModel`: This model is a
      specialized version of :class:`grammarinator.runtime.DefaultModel` that
@@ -95,21 +92,19 @@ models are:
                # (decimal and float), i.e., choosing the second alternative.
                if idx == 1:
                    weights[1] *= 5
-               return super().choice(node, idx, weights)
+               return super(DispatchingModel, self).choice(node, idx, weights)
 
-          def quantify_float(self, node, idx, min, max):
-              if idx == 1:
-                  # Generate floats with two decimal digits at least.
-                  min = 2
-              yield from super().quantify(node, idx, min, max)
+           def quantify_Float(self, node, idx, cnt, start, stop):
+               if idx == 1:
+                   # Generate floats with two decimal digits at least.
+                   start = 2
+               return super(DispatchingModel, self).quantify(node, idx, cnt, start, stop)
 
-          def charset_decimal(self, node, idx, chars):
-              # Ensure not choosing `0` as the first digit of a decimal.
-              if len(node.children) == 0:
-                  non_zero_chars = chars[:]
-                  non_zero_chars.remove('0')
-                  return super().charset(node, idx, non_zero_chars)
-              return super().charset(node, idx, chars)
+           def charset_Decimal(self, node, idx, chars):
+               # Ensure not choosing `0` as the first digit of a decimal.
+               if len(node.src) == 0:
+                   chars = tuple(c for c in chars if c != '0')
+               return super(DispatchingModel, self).charset(node, idx, chars)
 
   3. :class:`grammarinator.runtime.WeightedModel`: This model modifies the
      behavior of another model by adjusting (pre-multiplying) the weights of

--- a/grammarinator/runtime/model.py
+++ b/grammarinator/runtime/model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2023-2025 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -59,7 +59,7 @@ class Model:
             field identifies the corresponding grammar rule, which contains the
             charset.
         :param int idx: Index of the charset inside the current rule.
-        :param list[str] chars: List of characters to choose a single character
+        :param tuple[str] chars: List of characters to choose a single character
             from.
         :return: The chosen character.
         :rtype: str


### PR DESCRIPTION
- The example grammar was incorrect, at least for parsing. For ANTLR, character classes are invalid in parser rules, may only be used in lexer rules. Thus, grammar was rewritten to use lexer rules.
- In the python examples, indentation was off by one for `quantify` and `charset` methods. Fixed.
- The `quantify` methods in the examples used an old API: the number and names of arguments was incorrect, and the methods still acted as generators. So, the `cnt` argument was added, `min` and `max` were renamed to `start` and `stop`, and `return` was used instead of `yield`ing.
- Since the `decimal` rule in the grammar got turned into an lexer rule, `Decimal` nodes don't have children anymore. Thus, `charset` methods in the examples have been updated to make decisions based on token length instead of children count.
- It got revealed that `charset` methods don't get charsets as lists but as tuples. The documentation of `Model.charset` had to updated and example `charset` methods had to be adapted.
- All methods in the `DispatchingModel` subclass example fell into infinite recursion. The use of `super()` in the subclass directed the call to the method defined in `DispatchingModel`, which in turn called back into the subclass (and so on), instead of calling to the method in `DefaultModel`, the parent class of `DispatchingModel` and the grandparent of the subclass. Fixed by using the two-argument version of `super(..., ...)`.

Fixes: #272