### PR TITLE
Fix literal matching in parser

### DIFF
--- a/grammarinator/tool/parser.py
+++ b/grammarinator/tool/parser.py
@@ -259,8 +259,9 @@ class ParserTool:
                         return None, tree_node_pos
 
                     if isinstance(vertex, UnlexerRuleNode):
-                        if tree_node_pos < len(tree_nodes) and isinstance(tree_nodes[tree_node_pos], UnlexerRule) and (vertex.name == '_'.join(tree_nodes[tree_node_pos].name)
-                                                                                                                       or tree_nodes[tree_node_pos].name == ('<INVALID>',) and tree_nodes[tree_node_pos].src == vertex.out_neighbours[0].src):
+                        if (tree_node_pos < len(tree_nodes) and isinstance(tree_nodes[tree_node_pos], UnlexerRule)
+                            and (vertex.name == '_'.join(tree_nodes[tree_node_pos].name)
+                                 or tree_nodes[tree_node_pos].name == ('<INVALID>',) and vertex.name.startswith('T__') and tree_nodes[tree_node_pos].src == vertex.out_neighbours[0].src)):
                             seq_children += [tree_nodes[tree_node_pos]]
                             tree_node_pos += 1
                             continue


### PR DESCRIPTION
Ensure correct matching between grammar tree nodes and grammar graph lexer nodes by enforcing the following conditions:

* The grammar graph node must be an UnlexerRuleNode, and the tree node must be an UnlexerRule.
* Their names must match, or if the tree node is named ('<INVALID>',), the graph node’s name must start with T__, indicating a constant literal.
* In the latter case, the content of the literals must also be compared by checking the src field of the tree node against the src field of the single LiteralNode neighbor in the grammar graph.

This patch ensures that this comparison is correctly applied.