### PR TITLE
Fix child accessors to recursively visit internal nodes in Python and…

### DIFF
--- a/grammarinator-cxx/libgrammarinator/include/grammarinator/runtime/Rule.hpp
+++ b/grammarinator-cxx/libgrammarinator/include/grammarinator/runtime/Rule.hpp
@@ -340,18 +340,38 @@ public:
 
   Rule* get_child(const std::string& child_name, int index = 0) {
     int count = 0;
-    for (Rule* child : children) {
-      if (child->name == child_name && count++ == index)
-        return child;
+    std::vector<Rule*> worklist(children.rbegin(), children.rend());
+
+    while (!worklist.empty()) {
+      Rule* child = worklist.back();
+      worklist.pop_back();
+
+      if (child->type == Rule::UnparserRuleQuantifierType || child->type == Rule::UnparserRuleQuantifiedType || child->type == Rule::UnparserRuleAlternativeType) {
+        const auto& grandchildren = static_cast<ParentRule*>(child)->children;
+        worklist.insert(worklist.end(), grandchildren.rbegin(), grandchildren.rend());
+      } else if (child->name == child_name) {
+        if (count++ == index)
+          return child;
+      }
     }
     return nullptr;
   }
 
   const Rule* get_child(const std::string& child_name, int index = 0) const {
     int count = 0;
-    for (const Rule* child : children) {
-      if (child->name == child_name && count++ == index)
-        return child;
+    std::vector<const Rule*> worklist(children.rbegin(), children.rend());
+
+    while (!worklist.empty()) {
+      const Rule* child = worklist.back();
+      worklist.pop_back();
+
+      if (child->type == Rule::UnparserRuleQuantifierType || child->type == Rule::UnparserRuleQuantifiedType || child->type == Rule::UnparserRuleAlternativeType) {
+        const auto& grandchildren = static_cast<const ParentRule*>(child)->children;
+        worklist.insert(worklist.end(), grandchildren.rbegin(), grandchildren.rend());
+      } else if (child->name == child_name) {
+        if (count++ == index)
+          return child;
+      }
     }
     return nullptr;
   }

--- a/grammarinator/runtime/rule.py
+++ b/grammarinator/runtime/rule.py
@@ -380,7 +380,14 @@ class UnparserRule(ParentRule):
         if item in ['name', 'children']:
             raise AttributeError()
 
-        result = [child for child in self.children if child.name == item]
+        result = []
+        worklist = list(reversed(self.children))
+        while worklist:
+            child = worklist.pop()
+            if isinstance(child, ParentRule) and not isinstance(child, UnparserRule):
+                worklist.extend(reversed(child.children))
+            elif child.name == item:
+                result.append(child)
 
         if not result:
             raise AttributeError(f'[{self.name}] No child with name {item!r} {[child.name for child in self.children]}.')

--- a/tests/grammars/ChildAccessors.g4
+++ b/tests/grammars/ChildAccessors.g4
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 Renata Hodovan, Akos Kiss.
+ *
+ * Licensed under the BSD 3-Clause License
+ * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+ * This file may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+
+/*
+ * This test checks whether the children accessors work across alternatives
+ * and quantifiers.
+ */
+
+// TEST-PROCESS: {grammar}.g4 -o {tmpdir}
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -o {tmpdir}/{grammar}%d.txt
+
+grammar ChildAccessors;
+
+start: a=altTest q=quantTest {assert getattr($a, 'A') and getattr($q, 'B')};
+
+altTest: A | {False}? B;
+quantTest: B+;
+
+A: 'a';
+B: 'b';


### PR DESCRIPTION
… C++ backends

Child accessors allow UnparserRule instances to retrieve their children by name. However, the previous implementation did not account for intermediate nodes such as alternatives or quantifiers, which should be recursively visited when collecting actual UnlexerRule or UnparserRule children. This patch corrects the behavior by recursively visting such internal nodes in both the Python and C++ backends.

Co-authored by: Renáta Hodován <reni@inf.u-szeged.hu>