### PR TITLE
Add memoization of generated test cases to ensure uniqueness

### DIFF
--- a/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/GeneratorTool.hpp
+++ b/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/GeneratorTool.hpp
@@ -13,8 +13,11 @@
 #include "../util/print.hpp"
 #include "Tool.hpp"
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <list>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -35,6 +38,10 @@ private:
   bool enable_mutation;
   bool enable_recombination;
   bool keep_trees;
+  std::set<std::string> memo;
+  std::list<std::set<std::string>::iterator> memo_order;
+  int memo_size;
+  int unique_attempts;
   // bool cleanup;
   // std::string encoding;
   // std::string errors;
@@ -46,13 +53,14 @@ public:
                          runtime::Population* population = nullptr, bool generate = true, bool mutate = true,
                          bool recombine = true, bool unrestricted = true, bool keep_trees = false,
                          const std::vector<TransformerFn>& transformers = {}, SerializerFn serializer = nullptr,
+                         const int memo_size = 0, const int unique_attempts = 2,
                          // bool cleanup = true,
                          // const std::string& encoding = "utf-8",
                          // const std::string& errors = "strict",
                          bool dry_run = false, bool print_mutators = false)
       : Tool<GeneratorFactoryClass>(generator_factory, rule, limit, unrestricted, transformers, serializer, print_mutators),
         out_format(out_format), population(population), enable_generation(generate), enable_mutation(mutate),
-        enable_recombination(recombine), keep_trees(keep_trees),
+        enable_recombination(recombine), keep_trees(keep_trees), memo_size(memo_size), unique_attempts(std::max(unique_attempts, 1)),
         // cleanup(cleanup), encoding(encoding), errors(errors),
         dry_run(dry_run) {
     if (!out_format.empty() && !dry_run) {
@@ -70,8 +78,16 @@ public:
   ~GeneratorTool() override = default;
 
   std::string create_test(int index) {
-    auto root = create();
-    std::string test = this->serializer(root);
+    grammarinator::runtime::Rule* root;
+    std::string test;
+    for (int attempt = 1; attempt <= unique_attempts; ++attempt) {
+      root = create();
+      test = this->serializer(root);
+
+      if (memoize_test(test)) {
+        break;
+      }
+    }
 
     std::string test_fn;
     if (!dry_run) {
@@ -124,6 +140,33 @@ public:
     if (individual1) delete individual1;
     if (individual2) delete individual2;
     return root;
+  }
+
+private:
+
+  bool memoize_test(const std::string& test) {
+    // Memoize the test case. The size of the memo is capped by
+    // ``memo_size``, i.e., it contains at most that many test cases.
+    // Returns ``false`` if the test case was already in the memo, ``true``
+    // if it got added now (or memoization is disabled by ``memo_size=0``).
+    // When the memo is full and a new test case is added, the oldest entry
+    // is evicted.
+    if (memo_size < 1) {
+      return true;
+    }
+
+    auto inserted = memo.insert(test);  // {iterator, success}
+    if (!inserted.second) {
+      return false;
+    }
+    memo_order.push_back(inserted.first);
+
+    if (memo.size() > memo_size) {
+      memo.erase(memo_order.front());
+      memo_order.pop_front();
+    }
+
+    return true;
   }
 };
 

--- a/grammarinator-cxx/tools/generate.cpp
+++ b/grammarinator-cxx/tools/generate.cpp
@@ -92,6 +92,16 @@ int main(int argc, char **argv) {
        "number of tests to generate",
        cxxopts::value<int>()->default_value("1"),
        "NUM")
+      ("memo-size",
+       "memoize the last NUM unique tests; if a memoized test case is generated again, it is discarded and generation of a unique test case is retried",
+       cxxopts::value<int>()->default_value("0"),
+       "NUM"
+      )
+      ("unique-attempts",
+       "limit on how many times to try to generate a unique (i.e., non-memoized) test case; no effect if --memo-size=0",
+       cxxopts::value<int>()->default_value("2"),
+       "NUM"
+      )
       ("random-seed",
        "initialize random number generator with fixed seed (not set by default)",
        cxxopts::value<int>(),
@@ -138,6 +148,8 @@ int main(int argc, char **argv) {
                             args["keep-trees"].as<bool>(),  // keep_trees
                             GRAMMARINATOR_TRANSFORMER ? std::vector<Rule*(*)(Rule*)>{GRAMMARINATOR_TRANSFORMER} : std::vector<Rule*(*)(Rule*)>{},  // transformers
                             GRAMMARINATOR_SERIALIZER,  // serializer
+                            args["memo-size"].as<int>(),  // memo-size
+                            args["unique-attempts"].as<int>(),  // unique-attempts
                             args["dry-run"].as<bool>(),  // dry-run
                             false  // print_mutators
                             );

--- a/grammarinator/generate.py
+++ b/grammarinator/generate.py
@@ -62,6 +62,7 @@ def generator_tool_helper(args, lock=None):
                          population=DefaultPopulation(args.population, args.tree_extension, args.tree_codec) if args.population else None,
                          generate=args.generate, mutate=args.mutate, recombine=args.recombine, unrestricted=args.unrestricted, keep_trees=args.keep_trees,
                          transformers=args.transformer, serializer=args.serializer,
+                         memo_size=args.memo_size, unique_attempts=args.unique_attempts,
                          cleanup=False, encoding=args.encoding, errors=args.encoding_errors, dry_run=args.dry_run)
 
 
@@ -119,6 +120,10 @@ def execute():
                         help='print test cases to stdout (alias for --out=%(const)r)')
     parser.add_argument('-n', default=1, type=int_or_inf, metavar='NUM',
                         help='number of tests to generate, \'inf\' for continuous generation (default: %(default)s).')
+    parser.add_argument('--memo-size', default=0, type=int, metavar='NUM',
+                        help='memoize the last NUM unique tests; if a memoized test case is generated again, it is discarded and generation of a unique test case is retried (default: %(default)s).')
+    parser.add_argument('--unique-attempts', default=2, type=int, metavar='NUM',
+                        help='limit on how many times to try to generate a unique (i.e., non-memoized) test case; no effect if --memo-size=0 (default: %(default)s).')
     parser.add_argument('--random-seed', type=int, metavar='NUM',
                         help='initialize random number generator with fixed seed (not set by default).')
     parser.add_argument('--dry-run', default=False, action='store_true',


### PR DESCRIPTION
This patch introduces memoization support for both the Python and C++ backends, ensuring that each blackbox generator produces at least the user-specified number of unique test cases - provided that they can be generated within the configured maximum number of attempts per test case.

Co-authored by: Renáta Hodován <reni@inf.u-szeged.hu>