### PR TITLE
Add the grammarinator- prefix to the name of the generate-* binary

### DIFF
--- a/grammarinator-cxx/tools/CMakeLists.txt
+++ b/grammarinator-cxx/tools/CMakeLists.txt
@@ -7,11 +7,11 @@
 
 if(GRAMMARINATOR_TOOLS)
     find_package(cxxopts REQUIRED)
-    grammarinator_spec_target_name(GENERATE generate)
+    grammarinator_spec_target_name(GENERATE grammarinator-generate)
     add_executable(${GENERATE} generate.cpp)
     grammarinator_spec_definitions(${GENERATE})
     target_link_libraries(${GENERATE} grammarinator cxxopts::cxxopts -std=c++20)
-    # install(TARGETS ${GENERATE} DESTINATION bin)
+    install(TARGETS ${GENERATE} DESTINATION bin)
 endif()
 
 if(GRAMMARINATOR_FUZZNULL)


### PR DESCRIPTION
When building the C++ version, the binary executable tool that generates test cases was named `generate-SUFFIX` (where `SUFFIX` stands for the grammar/format used). To make the naming more aligned with the Python version and to make the tool's relation to Grammarinator clearer, the name of the tool is prefixed with `grammarinator-`.

Also added directives on how to install the tool if the project is installed.