### PR TITLE
Remove support of Python 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13', 'pypy-3.10']
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13', 'pypy-3.10']
     runs-on: ${{ matrix.os }}
     steps:
       - run: git config --global core.autocrlf input

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ The `trophy page`_ of the found issues is available from the wiki.
 Requirements
 ============
 
-* Python_ >= 3.8
+* Python_ >= 3.9
 * Java_ SE >= 11 JRE or JDK (the latter is optional)
 
 .. _Python: https://www.python.org

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -27,7 +26,7 @@ platform = any
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.8
+python_requires = >=3.9
 install_requires =
     antlerinator>=1!3.0.0
     antlr4-python3-runtime==4.13.2


### PR DESCRIPTION
Python 3.8 reached its end of life in October 2024, hence we do not support it either.