### PR TITLE
Simplify DefaultPopulation file naming

### DIFF
--- a/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/DefaultPopulation.hpp
+++ b/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/DefaultPopulation.hpp
@@ -10,7 +10,6 @@
 
 #include "../runtime/Population.hpp"
 #include "../util/print.hpp"
-#include "../util/random.hpp"
 #include "FlatBuffersTreeCodec.hpp"
 #include "TreeCodec.hpp"
 
@@ -87,23 +86,12 @@ public:
   bool empty() const override { return files_.size() == 0; }
 
   void add_individual(runtime::Rule* root, const std::string& path = "") override {
-    char uid[32];
-    for (int i = 0; i < 16; i++) {
-      const char hex[] = "0123456789abcdef";
-      uint8_t byte = util::random_int<uint8_t>(0, 255);
-      uid[i * 2] = hex[byte >> 4];
-      uid[i * 2 + 1] = hex[byte & 0xf];
-    }
+    std::string fn = std::filesystem::path(path).filename();
 
-    std::filesystem::path stem = std::filesystem::path(path).filename();
-    while (!stem.extension().empty()) {
-      stem = stem.stem();
-    }
-    std::string fn = stem;
     if (fn.empty()) {
       fn = "DefaultPopulation";
     }
-    fn = std::filesystem::path(directory_) / (fn + "." + std::string(uid, uid + 32) + "." + extension_);
+    fn = std::filesystem::path(directory_) / (fn + "." + extension_);
 
     save(fn, root);
     files_.push_back(fn);

--- a/grammarinator/tool/default_population.py
+++ b/grammarinator/tool/default_population.py
@@ -14,7 +14,6 @@ import random
 
 from os.path import basename, join
 from typing import Optional
-from uuid import uuid4
 
 from ..runtime import Annotations, Individual, Population, Rule
 from .tree_codec import AnnotatedTreeCodec, PickleTreeCodec, TreeCodec
@@ -51,20 +50,12 @@ class DefaultPopulation(Population):
     def add_individual(self, root: Rule, path: Optional[str] = None) -> None:
         """
         Save the tree to a new file. The name of the tree file is determined
-        based on the pathname of the corresponding test case. From the pathname
-        of the test case, the base name is kept up to the first period only. If
-        no file name can be determined, the population class name is used as a
-        fallback. To avoid naming conflicts, a unique identifier is concatenated
-        to the file name.
+        from the basename of the given path, or from the population class name
+        if none is provided. The output file is saved with the appropriate
+        extension defined by the current tree codec.
         """
-        if path:
-            path = basename(path)
-        if path:
-            path = path.split('.')[0]
-        if not path:
-            path = type(self).__name__
-
-        fn = join(self._directory, f'{path}.{uuid4().hex}.{self._extension}')
+        path = basename(path) if path else type(self).__name__
+        fn = join(self._directory, f'{path}.{self._extension}')
         self._save(fn, root)
         self._files.append(fn)
 


### PR DESCRIPTION
File names are now derived directly from the associated test name with the encoder-specific extension. When no test name is provided, we fall back to the population class name. This makes it easier to map tests to their tree representations while avoiding unnecessary noise in file names. The change is implemented both in Pyhon and C++ runtimes.