### PR TITLE
Change C++ build helper to resolve install prefix relative to CWD instead of project root

### DIFF
--- a/grammarinator-cxx/dev/build.py
+++ b/grammarinator-cxx/dev/build.py
@@ -25,7 +25,7 @@ def generate_build_options(args):
 
     build_options_append('CMAKE_BUILD_TYPE', args.build_type)
     build_options_append('CMAKE_VERBOSE_MAKEFILE', 'ON' if args.verbose else 'OFF')
-    build_options_append('CMAKE_INSTALL_PREFIX', args.install)
+    build_options_append('CMAKE_INSTALL_PREFIX', os.path.abspath(args.install) if args.install else None)
     build_options_append('GRAMMARINATOR_TOOLS', 'ON' if args.tools else 'OFF')
     build_options_append('GRAMMARINATOR_GRLF', 'ON' if args.grlf else 'OFF')
     build_options_append('GRAMMARINATOR_FUZZNULL', 'ON' if args.fuzznull else 'OFF')


### PR DESCRIPTION
The include directory is already turned into an absolute path relative to the current working directory (when `build.py` is called). However, the install prefix (if given) has been directly passed to cmake -- but the CWD for cmake has been changed to the root of the C++ code base, and so the install prefix was always interpreted relative to the C++ project root.

This could cause ambiguity on the command line if `build.py` was not executed from the root of the C++ code base. (Two directories had to be specified relative to two different bases.)

This change helps unify this by also turning the install prefix into an absolute path relative to CWD before passing it to cmake.