### PR TITLE
Run sphinx-build from the docs directory when toxing

### DIFF
--- a/docs/guide/fuzzer_building.rst
+++ b/docs/guide/fuzzer_building.rst
@@ -84,7 +84,7 @@ done using the ``build.py`` utility script, which is located in
 
 .. describe:: The CLI of grammarinator-cxx/dev/build.py
 
-.. runcmd:: python3 grammarinator-cxx/dev/build.py --help
+.. runcmd:: python ../grammarinator-cxx/dev/build.py --help
    :syntax: none
 
 The ``build.py`` script takes the configuration of the desired generator and

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,8 @@ commands =
 
 [testenv:docs]
 deps = -rdocs/requirements.txt
-commands = sphinx-build docs {envtmpdir} -E -n
+changedir = docs
+commands = sphinx-build . {envtmpdir} -E -n
 usedevelop = true
 
 [testenv:build]


### PR DESCRIPTION
This is to align the local current working directory of Sphinx with the one used on ReadTheDocs. This ensures that runcmd directives find programs to be executed consistently on the same paths. (And so, we don't get "No such file or directory" error messages instead of nice command outputs.)

(The change is somewhat speculative, but there is no way of testing it other than pushing it to RTD and crossing fingers.)