### PR TITLE
Use SPDX short-form license identifier to describe license

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,11 +6,10 @@ long_description_content_type = text/x-rst
 author = Renata Hodovan, Akos Kiss
 author_email = hodovan@inf.u-szeged.hu, akiss@inf.u-szeged.hu
 url = https://github.com/renatahodovan/grammarinator
-license = BSD
+license_expression = BSD-3-Clause
 license_files = LICENSE.rst
 classifiers =
     Intended Audience :: Developers
-    License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3


### PR DESCRIPTION
The license core metadata field has been deprecated and was replaced by the SPDX-based license-expression field. This change gets rid of the

    "Please consider removing the following classifiers in favor of a SPDX license expression"

messages when packaging.