### PR TITLE
Enable subprocess patch for coverage measurement

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ usedevelop = true
 
 [coverage:run]
 omit = **/tool/g4/*
+patch = subprocess
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
From pytest-cov 7.0.0 (released on 2025-09-09), the support for subprocess measurement has been dropped. This has caused drastic loss of information. The patch system of the underlying coverage package (since 7.10) has a way to measure subprocesses created in tests, but it needs to be enabled explicitly.