### PR TITLE
Add memoization to LibFuzzer integration as well

### DIFF
--- a/grammarinator-cxx/conanfile.txt
+++ b/grammarinator-cxx/conanfile.txt
@@ -2,6 +2,7 @@
 cxxopts/3.2.0
 nlohmann_json/3.11.3
 flatbuffers/24.12.23
+xxhash/0.8.3
 
 [generators]
 CMakeDeps

--- a/grammarinator-cxx/libgrammarinator/CMakeLists.txt
+++ b/grammarinator-cxx/libgrammarinator/CMakeLists.txt
@@ -7,6 +7,7 @@
 
 find_package(flatbuffers REQUIRED)
 find_package(nlohmann_json REQUIRED)
+find_package(xxhash REQUIRED)
 
 build_flatbuffers(${CMAKE_SOURCE_DIR}/../grammarinator/tool/resources/fbs/FBRule.fbs
                   ""
@@ -20,7 +21,7 @@ add_library(grammarinator INTERFACE)
 target_include_directories(grammarinator INTERFACE
                            ${CMAKE_CURRENT_SOURCE_DIR}/include
                            ${CMAKE_CURRENT_BINARY_DIR}/generated_include)
-target_link_libraries(grammarinator INTERFACE flatbuffers::flatbuffers nlohmann_json::nlohmann_json)
+target_link_libraries(grammarinator INTERFACE flatbuffers::flatbuffers nlohmann_json::nlohmann_json xxHash::xxhash)
 add_dependencies(grammarinator grammarinator_tool_fbs)
 
 configure_file(libgrammarinator.pc.in libgrammarinator.pc @ONLY)

--- a/grammarinator-cxx/libgrlf/grlf.cpp
+++ b/grammarinator-cxx/libgrlf/grlf.cpp
@@ -26,6 +26,7 @@ struct {
   bool random_mutators = true;
   int max_tokens = 0;
   int max_depth = 0;
+  int memo_size = 0;
 } settings;
 
 void initialize_int_arg(const std::string& arg, const std::string& name, int& dest) {
@@ -84,6 +85,7 @@ libfuzzer_tool() {
        settings.random_mutators,
        GRAMMARINATOR_TRANSFORMER ? std::vector<grammarinator::runtime::Rule* (*)(grammarinator::runtime::Rule*)>{GRAMMARINATOR_TRANSFORMER} : std::vector<grammarinator::runtime::Rule* (*)(grammarinator::runtime::Rule*)>{},
        GRAMMARINATOR_SERIALIZER,
+       settings.memo_size,
        treeCodec,
        settings.print_mutators);
 
@@ -110,6 +112,7 @@ int GrammarinatorInitialize(int* argc, char*** argv) {
       initialize_bool_arg((*argv)[i], "random_mutators", settings.random_mutators);
       initialize_int_arg((*argv)[i], "max_tokens", settings.max_tokens);
       initialize_int_arg((*argv)[i], "max_depth", settings.max_depth);
+      initialize_int_arg((*argv)[i], "memo_size", settings.memo_size);
     }
   }
   return 0;

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     inators
     jinja2
     regex
+    xxhash
 
 [options.packages.find]
 exclude = tests


### PR DESCRIPTION
In addition to adding memoization support to LibFuzzer, its behavior has been adjusted: rather than storing the full raw test case in the memo, only its xxh hash is recorded.