### PR TITLE
Change test job matrix fail-fast strategy to false

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.9, '3.10', '3.11', '3.12', '3.13', 'pypy-3.11']


### PR DESCRIPTION
So, a single fail does not cancel all other tests (and so a restart triggers less jobs to run).