### PR TITLE
Require package xxHash in CMakeLists

### DIFF
--- a/grammarinator-cxx/libgrammarinator/CMakeLists.txt
+++ b/grammarinator-cxx/libgrammarinator/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 find_package(flatbuffers REQUIRED)
 find_package(nlohmann_json REQUIRED)
-find_package(xxhash REQUIRED)
+find_package(xxHash REQUIRED)
 
 add_library(flatbuffers_headers INTERFACE)
 target_include_directories(flatbuffers_headers INTERFACE ${flatbuffers_INCLUDE_DIRS})


### PR DESCRIPTION
Requiring xxhash seems to fail on Linux, while it works on MacOS and Windows. May be caused by case-sensitive/insensitive file system differences.