### PR TITLE
Second try to improve the configuration of libgrlf and tools

### DIFF
--- a/grammarinator-cxx/CMakeLists.txt
+++ b/grammarinator-cxx/CMakeLists.txt
@@ -51,7 +51,7 @@ macro(grammarinator_spec_definitions TARGET)
   if (NOT ("${GRAMMARINATOR_INCLUDEDIR}" STREQUAL ""))
     target_include_directories(${TARGET} PRIVATE "${GRAMMARINATOR_INCLUDEDIR}")
   endif()
-  target_include_directories(${TARGET} PRIVATE "${CMAKE_SOURCE_DIR}/common")
+  target_include_directories(${TARGET} PRIVATE "${CMAKE_SOURCE_DIR}/config")
 endmacro()
 
 execute_process(COMMAND git describe --tags

--- a/grammarinator-cxx/config/grammarinator/config.hpp
+++ b/grammarinator-cxx/config/grammarinator/config.hpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2025 Renata Hodovan, Akos Kiss.
+//
+// Licensed under the BSD 3-Clause License
+// <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+// This file may not be copied, modified, or distributed except
+// according to those terms.
+
+#ifndef GRAMMARINATOR_VERSION
+#define GRAMMARINATOR_VERSION "0.0 (unknown)"
+#endif
+
+#ifndef GRAMMARINATOR_GENERATOR
+#error "GRAMMARINATOR_GENERATOR must be defined"
+#endif
+
+#ifndef GRAMMARINATOR_MODEL
+#define GRAMMARINATOR_MODEL grammarinator::runtime::DefaultModel
+#endif
+
+#ifndef GRAMMARINATOR_LISTENER
+#define GRAMMARINATOR_LISTENER grammarinator::runtime::Listener
+#endif
+
+#ifndef GRAMMARINATOR_TRANSFORMER
+#define GRAMMARINATOR_TRANSFORMER nullptr
+#endif
+
+#ifndef GRAMMARINATOR_SERIALIZER
+#define GRAMMARINATOR_SERIALIZER grammarinator::runtime::SimpleSpaceSerializer
+#endif
+
+#ifndef GRAMMARINATOR_TREECODEC
+#define GRAMMARINATOR_TREECODEC grammarinator::tool::FlatBuffersTreeCodec
+#endif
+
+#ifndef GRAMMARINATOR_INCLUDE
+#define GRAMMARINATOR_INCLUDE GRAMMARINATOR_GENERATOR.hpp
+#endif
+
+#define GRAMMARINATOR_STRFY_INTERNAL(MACRO) #MACRO
+#define GRAMMARINATOR_STRFY(MACRO) GRAMMARINATOR_STRFY_INTERNAL(MACRO)
+#include GRAMMARINATOR_STRFY(GRAMMARINATOR_INCLUDE)

--- a/grammarinator-cxx/dev/build.py
+++ b/grammarinator-cxx/dev/build.py
@@ -102,15 +102,15 @@ def main():
     sgrp.add_argument('--generator', metavar='NAME',
                       help='name of the generator class')
     sgrp.add_argument('--model', metavar='NAME',
-                      help='name of the model class (default if --include is not specified: grammarinator::runtime::DefaultModel)')
+                      help='name of the model class (default: grammarinator::runtime::DefaultModel)')
     sgrp.add_argument('--listener', metavar='NAME',
-                      help='name of the listener class (default if --include is not specified: grammarinator::runtime::Listener)')
+                      help='name of the listener class (default: grammarinator::runtime::Listener)')
     sgrp.add_argument('--transformer', metavar='NAME',
-                      help='name of the transformer function (default if --include is not specified: nullptr)')
+                      help='name of the transformer function (default: nullptr, signaling no transformer)')
     sgrp.add_argument('--serializer', metavar='NAME',
-                      help='name of the serializer function (default if --include is not specified: grammarinator::runtime::SimpleSpaceSerializer)')
+                      help='name of the serializer function (default: grammarinator::runtime::SimpleSpaceSerializer)')
     sgrp.add_argument('--tree-format', metavar='NAME', choices=['json', 'flatbuffers'],
-                      help='format of the saved trees (choices: %(choices)s; default if --include is not specified: flatbuffers)')
+                      help='format of the saved trees (choices: %(choices)s; default: flatbuffers)')
     sgrp.add_argument('--include', metavar='FILE',
                       help='file to include when compiling the specialized artefacts (default: derived from the generator class name by appending .hpp)')
     sgrp.add_argument('--includedir', metavar='DIR',
@@ -119,21 +119,13 @@ def main():
                       help='suffix of the specialized artefacts, possibly referring to the input format (default: derived from the generator class name by removing Generator and lowercasing)')
 
     args = parser.parse_args()
+    args.treecodec = {
+        'flatbuffers':'FlatBuffersTreeCodec',
+        'json': 'NlohmannJsonTreeCodec'
+    }[args.tree_format] if args.tree_format else None
 
     if (args.grlf or args.tools) and (not args.includedir or not args.generator):
         parser.error('To build specialized artefacts, the `--generator` and `--includedir` arguments must be defined.')
-
-    if args.generator and not args.include:
-        args.model = args.model or 'grammarinator::runtime::DefaultModel'
-        args.listener = args.listener or 'grammarinator::runtime::Listener'
-        args.transformer = args.transformer or 'nullptr'
-        args.serializer = args.serializer or 'grammarinator::runtime::SimpleSpaceSerializer'
-        args.tree_format = args.tree_format or 'flatbuffers'
-        args.treecodec = {
-            'flatbuffers':'grammarinator::tool::FlatBuffersTreeCodec',
-            'json': 'grammarinator::tool::NlohmannJsonTreeCodec'
-        }[args.tree_format]
-        args.include = args.generator + '.hpp'
 
     try:
         configure_cmake(args)

--- a/grammarinator-cxx/libgrlf/grlf.cpp
+++ b/grammarinator-cxx/libgrlf/grlf.cpp
@@ -16,9 +16,7 @@
 #include <string>
 #include <vector>
 
-#define GRAMMARINATOR_STRFY_INTERNAL(MACRO) #MACRO
-#define GRAMMARINATOR_STRFY(MACRO) GRAMMARINATOR_STRFY_INTERNAL(MACRO)
-#include GRAMMARINATOR_STRFY(GRAMMARINATOR_INCLUDE)
+#include "grammarinator/config.hpp"
 
 namespace {
 

--- a/grammarinator-cxx/tools/generate.cpp
+++ b/grammarinator-cxx/tools/generate.cpp
@@ -18,9 +18,7 @@
 #include <string>
 #include <tuple>
 
-#define GRAMMARINATOR_STRFY_INTERNAL(MACRO) #MACRO
-#define GRAMMARINATOR_STRFY(MACRO) GRAMMARINATOR_STRFY_INTERNAL(MACRO)
-#include GRAMMARINATOR_STRFY(GRAMMARINATOR_INCLUDE)
+#include "grammarinator/config.hpp"
 
 using namespace grammarinator::runtime;
 using namespace grammarinator::tool;


### PR DESCRIPTION
Revert most of the previous patch that removed config.h. This commit restores config.h renamed as grammarinator/config.hpp, while removing the disturbing warning messages and the superfluous includes.