### PR TITLE
Improve standard-conformance of the C++ code base

### DIFF
--- a/grammarinator-cxx/tools/generate.cpp
+++ b/grammarinator-cxx/tools/generate.cpp
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
        "NAME")
       ("o,out",
        "output file name pattern",
-       cxxopts::value<std::string>()->default_value(std::filesystem::current_path() / "tests" / "test_%d"),
+       cxxopts::value<std::string>()->default_value((std::filesystem::current_path() / "tests" / "test_%d").string()),
        "FILE")
       ("stdout",
        "print test cases to stdout (alias for --out='')",


### PR DESCRIPTION
- Use `std::filesystem`-based techniques to collect files in a directory instead of `glob.h`, which is POSIX-only.
- Avoid implicit conversions between `std::filesystem::path` and `std::string`.

This helps a lot on non-POSIX systems like Windows/MSVC.