### PR TITLE
Rename NlohmannJsonTreeCodec to JsonTreeCodec

### DIFF
--- a/grammarinator-cxx/dev/build.py
+++ b/grammarinator-cxx/dev/build.py
@@ -121,7 +121,7 @@ def main():
     args = parser.parse_args()
     args.treecodec = {
         'flatbuffers':'FlatBuffersTreeCodec',
-        'json': 'NlohmannJsonTreeCodec'
+        'json': 'JsonTreeCodec'
     }[args.tree_format] if args.tree_format else None
 
     if (args.grlf or args.tools) and (not args.includedir or not args.generator):

--- a/grammarinator-cxx/libgrammarinator/include/grammarinator/tool.hpp
+++ b/grammarinator-cxx/libgrammarinator/include/grammarinator/tool.hpp
@@ -13,8 +13,8 @@
 #include "tool/FlatBuffersTreeCodec.hpp"
 #include "tool/GeneratorFactory.hpp"
 #include "tool/GeneratorTool.hpp"
+#include "tool/JsonTreeCodec.hpp"
 #include "tool/LibFuzzerTool.hpp"
-#include "tool/NlohmannJsonTreeCodec.hpp"
 #include "tool/Tool.hpp"
 #include "tool/TreeCodec.hpp"
 

--- a/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/JsonTreeCodec.hpp
+++ b/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/JsonTreeCodec.hpp
@@ -5,8 +5,8 @@
 // This file may not be copied, modified, or distributed except
 // according to those terms.
 
-#ifndef GRAMMARINATOR_TOOL_NLOHMANNJSONTREECODEC_HPP
-#define GRAMMARINATOR_TOOL_NLOHMANNJSONTREECODEC_HPP
+#ifndef GRAMMARINATOR_TOOL_JSONTREECODEC_HPP
+#define GRAMMARINATOR_TOOL_JSONTREECODEC_HPP
 
 #include "../util/print.hpp"
 #include "TreeCodec.hpp"
@@ -19,14 +19,14 @@
 namespace grammarinator {
 namespace tool {
 
-class NlohmannJsonTreeCodec : public TreeCodec {
+class JsonTreeCodec : public TreeCodec {
 public:
-  NlohmannJsonTreeCodec() = default;
-  NlohmannJsonTreeCodec(const NlohmannJsonTreeCodec& other) = delete;
-  NlohmannJsonTreeCodec& operator=(const NlohmannJsonTreeCodec& other) = delete;
-  NlohmannJsonTreeCodec(NlohmannJsonTreeCodec&& other) = delete;
-  NlohmannJsonTreeCodec& operator=(NlohmannJsonTreeCodec&& other) = delete;
-  ~NlohmannJsonTreeCodec() override = default;
+  JsonTreeCodec() = default;
+  JsonTreeCodec(const JsonTreeCodec& other) = delete;
+  JsonTreeCodec& operator=(const JsonTreeCodec& other) = delete;
+  JsonTreeCodec(JsonTreeCodec&& other) = delete;
+  JsonTreeCodec& operator=(JsonTreeCodec&& other) = delete;
+  ~JsonTreeCodec() override = default;
 
   std::vector<uint8_t> encode(runtime::Rule* root) const override {
     std::string str = toJson(root).dump(-1, ' ', true, nlohmann::detail::error_handler_t::ignore);
@@ -118,4 +118,4 @@ private:
 } // namespace tool
 } // namespace grammarinator
 
-#endif  // GRAMMARINATOR_TOOL_NLOHMANNJSONTREECODEC_HPP
+#endif  // GRAMMARINATOR_TOOL_JSONTREECODEC_HPP

--- a/grammarinator-cxx/tools/generate.cpp
+++ b/grammarinator-cxx/tools/generate.cpp
@@ -29,7 +29,7 @@ TreeCodec* treecodec_factory() { return new T(); }
 
 static const std::map<std::string, std::tuple<std::string, TreeCodec*(*)()>> tree_formats = {
   {"flatbuffers", {"grtf", treecodec_factory<FlatBuffersTreeCodec>}},
-  {"json", {"grtj", treecodec_factory<NlohmannJsonTreeCodec>}},
+  {"json", {"grtj", treecodec_factory<JsonTreeCodec>}},
 };
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
The underlying implementation should not be reflected in the name of the codec as it should not matter.