### PR TITLE
Improvements of the testing infrastructure

### DIFF
--- a/tests/grammars/UnicodePropertiesParser.g4
+++ b/tests/grammars/UnicodePropertiesParser.g4
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Renata Hodovan, Akos Kiss.
+ * Copyright (c) 2023-2025 Renata Hodovan, Akos Kiss.
  *
  * Licensed under the BSD 3-Clause License
  * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -14,6 +14,7 @@
 // TEST-PROCESS: {grammar}Parser.g4 {grammar}Lexer.g4 -o {tmpdir}
 // TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -o {tmpdir}/{grammar}%d.txt
 // TEST-ANTLR: {grammar}Parser.g4 {grammar}Lexer.g4 -o {tmpdir}
+// TEST-SKIP: difference between Unicode versions used by Grammarinator and ANTLR
 // TEST-REPARSE: -p {grammar}Parser -l {grammar}Lexer -r start {tmpdir}/{grammar}%d.txt
 
 parser grammar UnicodePropertiesParser;


### PR DESCRIPTION
- The grammars collected for testing are returned (and, thus, tested) in alphabetical order for stability.
- Tests can contain an additional new test command `TEST-SKIP` to signal if a grammar is to be skipped from testing for some reason.
- The docstring of the implementation of the test command `TEST_GENERATE` has been updated not to mention separate unlexers and unparsers.

Use `TEST-SKIP` to skip parts of grammar tests that have problems:

- UnicodeProperties{Lexer,Parser}.g4 have been failing notoriously because of Unicode version differences between Grammarinator and ANTLR. Thus, the reparsing step of the test is skipped.