### PR TITLE
Change the CLI of Python tools

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,8 +153,8 @@ different fuzzing strategies.
 
 Basic command line syntax of ``grammarinator-parse``::
 
-  grammarinator-parse <grammar-file(s)> -r <start-rule> \
-    -i <input_file(s)> -o <output-directory>
+  grammarinator-parse -g <grammar-file(s)> -r <start-rule> \
+    -o <output-directory> <input_file(s)>
 
 Having a population of such ``.grt*`` files, ``grammarinator-generate`` or
 ``grammarinator-generate-<name>`` can make use of them with the

--- a/docs/guide/fuzzer_building.rst
+++ b/docs/guide/fuzzer_building.rst
@@ -51,11 +51,11 @@ methods corresponding to each rule defined in the grammar.
    :replace: "process.py/grammarinator-process"
 
 The usage of ``grammarinator-process`` is straigthforward: it processes the
-grammars defined as ``FILE`` encoded with the ``--encoding`` option
-(default: ``utf-8``) and generates the output in the directory specified by
-``--out`` (default is the current working directory). The generated code is
-written in the programming language specified by ``--language`` (currently,
-the available options are ``py`` for Python and ``hpp`` for C++).
+specified grammars encoded with the ``--encoding`` option (default: ``utf-8``)
+and generates the output in the directory specified by ``--out`` (default is the
+current working directory). The generated code is written in the programming
+language specified by ``--language`` (currently, the available options are
+``py`` for Python and ``hpp`` for C++).
 
 If the grammar contains parser-specific or unnecessary inline actions, they
 can be ignored by using the ``--no-actions`` option. The grammars can also

--- a/docs/guide/population.rst
+++ b/docs/guide/population.rst
@@ -70,15 +70,15 @@ variations and explore different test cases.
 
 The usage of the ``grammarinator-parse`` utility is generally straightforward.
 It takes a set of inputs and processes them with the specified grammars
-(``FILE``). Inputs can be listed as files or directories (using ``--input``), or
-specified with file patterns (using ``--glob``). The listed directories are
-traversed recursively. The start rule, which determines the root of every tree
-in the population, can be defined using the ``--rule`` argument.
-The ``--tree-format`` option controls the serialization format of the output
-trees. If omitted, the default is ``flatbuffer`` (producing ``.grtf`` files). After
-the parsing is completed and the tree is created, various
-:doc:`transformers <transformers>` (``--transformer``) can be applied to
-modify the tree before saving it to the file system using the ``--out`` option.
+(``-g``). Inputs can be listed as files or directories (``FILE``), or specified
+with file patterns (using ``--glob``). The listed directories are traversed
+recursively. The start rule, which determines the root of every tree in the
+population, can be defined using the ``--rule`` argument. The ``--tree-format``
+option controls the serialization format of the output trees. If omitted, the
+default is ``flatbuffer`` (producing ``.grtf`` files). After the parsing is
+completed and the tree is created, various :doc:`transformers <transformers>`
+(``--transformer``) can be applied to modify the tree before saving it to the
+file system using the ``--out`` option.
 
 There are two settings that may require further explanation:
 
@@ -120,8 +120,8 @@ sources serialized according to the chosen method.
 
 ``grammarinator-decode`` processes a set of tree inputs and creates a
 test representation from them. Inputs can be listed as files or directories
-(using ``--input``), or specified with file patterns (using ``--glob``).
-The listed directories are traversed recursively.
+(``FILE``), or specified with file patterns (using ``--glob``). The listed
+directories are traversed recursively.
 First, the files are converted to trees using the appropriate tree codec
 specified by ``--tree-format``. The resulting trees are then serialized using
 the function defined by ``--serializer`` (or :class:`str` by default). The

--- a/examples/grammars/HTMLParser.g4
+++ b/examples/grammars/HTMLParser.g4
@@ -26,7 +26,7 @@
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-// TEST-PROCESS: {grammar}Parser.g4 {grammar}Lexer.g4 -o {tmpdir}
+// TEST-PROCESS: -g {grammar}Parser.g4 {grammar}Lexer.g4 -o {tmpdir}
 // TEST-GENERATE: {grammar}Generator.{grammar}Generator -r htmlDocument -s {grammar}Generator.html_space_serializer -j 2 -n 5 -o {tmpdir}/{grammar}G%d.html
 // TEST-GENERATE: {grammar}CustomGenerator.{grammar}CustomGenerator -r htmlDocument -s {grammar}Generator.html_space_serializer -j 2 -n 5 -o {tmpdir}/{grammar}C%d.html --sys-path ../fuzzer/
 

--- a/grammarinator/decode.py
+++ b/grammarinator/decode.py
@@ -45,10 +45,10 @@ def execute() -> None:
                             epilog="""
                             The tool decodes tree files and serializes them to test cases.
                             """)
-    parser.add_argument('-i', '--input', metavar='FILE', nargs='+',
-                        help='input files to process')
+    parser.add_argument('input', metavar='FILE', nargs='+',
+                        help='input files or directories to process')
     parser.add_argument('--glob', metavar='PATTERN', nargs='+',
-                        help='wildcard pattern for input files to process (supported wildcards: ?, *, **, [])')
+                        help='wildcard patterns for input files to process (supported wildcards: ?, *, **, [])')
     parser.add_argument('--ext', default='.txt',
                         help='extension to use when saving decoded trees (default: %(default)s).')
     parser.add_argument('-s', '--serializer', metavar='NAME', default=str,

--- a/grammarinator/parse.py
+++ b/grammarinator/parse.py
@@ -40,12 +40,12 @@ def execute():
                             compatible tree representations from them and saves them for further
                             reuse.
                             """)
-    parser.add_argument('grammar', metavar='FILE', nargs='+',
-                        help='ANTLR grammar files describing the expected format of input to parse.')
-    parser.add_argument('-i', '--input', metavar='FILE', nargs='+',
+    parser.add_argument('input', metavar='FILE', nargs='+',
                         help='input files or directories to process.')
     parser.add_argument('--glob', metavar='PATTERN', nargs='+',
                         help='wildcard patterns for input files to process (supported wildcards: ?, *, **, [])')
+    parser.add_argument('-g', '--grammar', metavar='FILE', nargs='+', required=True,
+                        help='ANTLR grammar files describing the expected format of input to parse.')
     parser.add_argument('-r', '--rule', metavar='NAME',
                         help='name of the rule to start parsing with (default: first parser rule).')
     parser.add_argument('-t', '--transformer', metavar='NAME', action='append', default=[],

--- a/grammarinator/process.py
+++ b/grammarinator/process.py
@@ -26,7 +26,9 @@ def execute():
         creates a fuzzer that can generate randomized content conforming to
         the format described by the grammar.
         """)
-    parser.add_argument('grammar', metavar='FILE', nargs='+',
+    parser.add_argument('grammar_pos', metavar='FILE', nargs='*', default=[],
+                        help='ANTLR grammar files describing the expected format to generate (alias for --grammar).')
+    parser.add_argument('-g', '--grammar', metavar='FILE', nargs='*', default=[],
                         help='ANTLR grammar files describing the expected format to generate.')
     parser.add_argument('-D', metavar='OPT=VAL', dest='options', default=[], action='append',
                         help='set/override grammar-level option')
@@ -48,6 +50,9 @@ def execute():
     add_version_argument(parser, version=__version__)
     args = parser.parse_args()
 
+    args.grammar.extend(args.grammar_pos)
+    if not args.grammar:
+        parser.error('at least one grammar file is required, either via --grammar or as a positional argument')
     for grammar in args.grammar:
         if not exists(grammar):
             parser.error(f'{grammar} does not exist.')

--- a/tests/grammars/LifeCycle.g4
+++ b/tests/grammars/LifeCycle.g4
@@ -26,15 +26,15 @@
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir}
 // TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -r start -n 3 -s grammarinator.runtime.simple_space_serializer -o {tmpdir}/{grammar}A%d.txt
-// TEST-PARSE: {grammar}.g4 -j 1 -i {tmpdir}/LifeCycleA0.txt {tmpdir}/LifeCycleA1.txt {tmpdir}/LifeCycleA2.txt -r start --hidden WS -o {tmpdir}/population/p/ --tree-format pickle
+// TEST-PARSE: -g {grammar}.g4 -j 1 -r start --hidden WS -o {tmpdir}/population/p/ --tree-format pickle {tmpdir}/LifeCycleA0.txt {tmpdir}/LifeCycleA1.txt {tmpdir}/LifeCycleA2.txt
 // TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -r start -n 3 --population {tmpdir}/population/p/ --tree-format pickle -o {tmpdir}/{grammar}PB%d.txt --keep-trees --no-generate --no-recombine
 // TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -r start -n 3 --population {tmpdir}/population/p/ --tree-format pickle -o {tmpdir}/{grammar}PC%d.txt --keep-trees --no-generate --no-mutate
 // TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 2 -r start -n 6 --population {tmpdir}/population/p/ --tree-format pickle -o {tmpdir}/{grammar}PD%d.txt --no-generate
-// TEST-PARSE: {grammar}.g4 -j 1 -i {tmpdir}/LifeCycleA0.txt {tmpdir}/LifeCycleA1.txt {tmpdir}/LifeCycleA2.txt -r start --hidden WS -o {tmpdir}/population/j/ --tree-format json
+// TEST-PARSE: -g {grammar}.g4 -j 1 -r start --hidden WS -o {tmpdir}/population/j/ --tree-format json {tmpdir}/LifeCycleA0.txt {tmpdir}/LifeCycleA1.txt {tmpdir}/LifeCycleA2.txt
 // TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -r start -n 3 --population {tmpdir}/population/j/ --tree-format json -o {tmpdir}/{grammar}JB%d.txt --keep-trees --no-generate --no-recombine
 // TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -r start -n 3 --population {tmpdir}/population/j/ --tree-format json -o {tmpdir}/{grammar}JC%d.txt --keep-trees --no-generate --no-mutate
 // TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 2 -r start -n 6 --population {tmpdir}/population/j/ --tree-format json -o {tmpdir}/{grammar}JD%d.txt --no-generate
-// TEST-PARSE: {grammar}.g4 -j 1 -i {tmpdir}/LifeCycleA0.txt {tmpdir}/LifeCycleA1.txt {tmpdir}/LifeCycleA2.txt -r start --hidden WS -o {tmpdir}/population/f/ --tree-format flatbuffers
+// TEST-PARSE: -g {grammar}.g4 -j 1 -r start --hidden WS -o {tmpdir}/population/f/ --tree-format flatbuffers {tmpdir}/LifeCycleA0.txt {tmpdir}/LifeCycleA1.txt {tmpdir}/LifeCycleA2.txt
 // TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -r start -n 3 --population {tmpdir}/population/f/ --tree-format flatbuffers -o {tmpdir}/{grammar}FB%d.txt --keep-trees --no-generate --no-recombine
 // TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 1 -r start -n 3 --population {tmpdir}/population/f/ --tree-format flatbuffers -o {tmpdir}/{grammar}FC%d.txt --keep-trees --no-generate --no-mutate
 // TEST-GENERATE: {grammar}Generator.{grammar}Generator -j 2 -r start -n 6 --population {tmpdir}/population/f/ --tree-format flatbuffers -o {tmpdir}/{grammar}FD%d.txt --no-generate


### PR DESCRIPTION
Where applicable, grammars should be passed using the -g/--grammar option (grammarinator-process, grammarinator-parse), while input files to be processed should be passed as positional arguments (grammarinator-parse, grammarinator-decode).

To help backward compatibility, the positional arguments of grammarinator-process have been kept as an alias for the --grammar option.