### PR TITLE
Update Python support: drop 3.9, add 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13', 'pypy-3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.11']
     runs-on: ${{ matrix.os }}
     steps:
       - run: git config --global core.autocrlf input

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ The `trophy page`_ of the found issues is available from the wiki.
 Requirements
 ============
 
-* Python_ >= 3.9
+* Python_ >= 3.10
 * Java_ SE >= 11 JRE or JDK (the latter is optional)
 
 Additionally, for the C++ backend:

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,11 +13,11 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Testing
     Typing :: Typed
@@ -26,7 +26,7 @@ platform = any
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     antlerinator>=1!3.0.0
     antlr4-python3-runtime==4.13.2


### PR DESCRIPTION
Python 3.14 has been released, while 3.9 reached its end of life.