### PR TITLE
Fix import grammar handling

### DIFF
--- a/grammarinator/tool/resources/codegen/GeneratorTemplate.hpp.jinja
+++ b/grammarinator/tool/resources/codegen/GeneratorTemplate.hpp.jinja
@@ -156,7 +156,7 @@ public:
     explicit {{ graph.name }}(Model* model=new DefaultModel(), const std::vector<Listener*>& listeners={}, const RuleSize& limit=RuleSize::max()) : {{ graph.superclass }}(model, listeners, limit) {}
 
     {% for rule in graph.imag_rules %}
-    UnlexerRule* {{ rule.id | join('_') }}(Rule *parent = nullptr) {
+    Rule* {{ rule.id | join('_') }}(Rule *parent = nullptr) {
         UnlexerRuleContext rule(this, "{{ rule.id | join('_') }}", parent);
         return rule.current();
     }

--- a/tests/grammars-cxx/ImportActionsTokens.g4
+++ b/tests/grammars-cxx/ImportActionsTokens.g4
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Renata Hodovan, Akos Kiss.
+ *
+ * Licensed under the BSD 3-Clause License
+ * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+ * This file may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+
+/*
+ * This test checks whether the grammar import mechanism works for named
+ * actions and tokens specifications.
+ */
+
+// TEST-PROCESS-CXX: {grammar}.g4 -o {tmpdir} --lib import
+// TEST-BUILD-CXX: --generator={grammar}Generator --includedir={tmpdir} --builddir={tmpdir}/build
+// TEST-GENERATE-CXX: {tmpdir}/build/bin/grammarinator-generate-{grammar_lower} -r start -o {tmpdir}/{grammar}%d.txt
+// TEST-ANTLR: {grammar}.g4 -o {tmpdir} -lib import
+
+grammar ImportActionsTokens;
+
+import ImportedActionsTokens;
+
+@header {
+inline std::string QUESTION = "What do you get when you multiply six by nine?";
+}
+
+@members {
+std::string _question() {
+    return QUESTION;
+}
+}
+
+tokens { Question, Space }
+
+start:
+    Question {static_cast<UnlexerRule*>(static_cast<UnparserRule*>(current)->last_child())->src = _question();}
+    Space {static_cast<UnlexerRule*>(static_cast<UnparserRule*>(current)->last_child())->src = " ";}
+    Answer {static_cast<UnlexerRule*>(static_cast<UnparserRule*>(current)->last_child())->src = _answer();}
+    {assert(std::format("{}", *current) == "What do you get when you multiply six by nine? 42");};

--- a/tests/grammars-cxx/Importer.g4
+++ b/tests/grammars-cxx/Importer.g4
@@ -9,8 +9,15 @@
 
 /*
  * This test checks whether the grammar import mechanism (using rules of a
- * different grammar) works, even from a different directory (via the `--lib`
- * CLI option).
+ * different grammar) works, i.e.,
+ * - a grammar can import multiple other grammars,
+ * - even an imported grammar can import further grammar(s),
+ * - if more than one imported grammar defines a rule, the first version found
+ *   is used,
+ * - both lexical and parser imported rules can be overridden.
+ *
+ * This test also checks that imports work even from a different directory (via
+ * the `--lib` CLI option).
  */
 
 // TEST-PROCESS-CXX: {grammar}.g4 -o {tmpdir} --lib import
@@ -21,8 +28,12 @@
 
 grammar Importer;
 
-import Importee;
+import Importee1, Importee2;
+// inherits Importee1.Token1 which hides Importee2.Token1
+// inherits Importee3.Token2 which hides Importee2.Token2
+// inherits Importee1.Token3 which hides Importee2.Token3
+// inherits Importee2.Token4
 
-start
-  : importee
-  ;
+start: Token1 Token2 Token3 Token4 Token5;  // overrides Importee1.start
+
+Token5: '\n';  // adds Token5

--- a/tests/grammars-cxx/import/ImportedActionsTokens.g4
+++ b/tests/grammars-cxx/import/ImportedActionsTokens.g4
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Renata Hodovan, Akos Kiss.
+ *
+ * Licensed under the BSD 3-Clause License
+ * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+ * This file may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+
+/* This grammar is used by ../ImportActionsTokens.g4 */
+
+grammar ImportedActionsTokens;
+
+@header {
+inline std::string ANSWER = "42";
+}
+
+@members {
+std::string _answer() {
+    return ANSWER;
+}
+}
+
+tokens { Answer, Space }

--- a/tests/grammars-cxx/import/Importee1.g4
+++ b/tests/grammars-cxx/import/Importee1.g4
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Renata Hodovan, Akos Kiss.
+ * Copyright (c) 2025 Renata Hodovan, Akos Kiss.
  *
  * Licensed under the BSD 3-Clause License
  * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -9,8 +9,12 @@
 
 /* This grammar is used by ../Importer.g4 */
 
-grammar Importee;
+grammar Importee1;
 
-importee
-  : 'pass'
-  ;
+import Importee3;
+
+start: Token1 Token2 Token3;
+
+Token1: 'a';  // overrides Importee3.Token1
+// inherits Importee3.Token2
+Token3: 'x';  // adds Token3

--- a/tests/grammars-cxx/import/Importee2.g4
+++ b/tests/grammars-cxx/import/Importee2.g4
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renata Hodovan, Akos Kiss.
+ *
+ * Licensed under the BSD 3-Clause License
+ * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+ * This file may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+
+/* This grammar is used by ../Importer.g4 */
+
+grammar Importee2;
+
+Token1: 'b';
+Token2: '+';
+Token3: 'y';
+Token4: ';';

--- a/tests/grammars-cxx/import/Importee3.g4
+++ b/tests/grammars-cxx/import/Importee3.g4
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Renata Hodovan, Akos Kiss.
+ *
+ * Licensed under the BSD 3-Clause License
+ * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+ * This file may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+
+/* This grammar is used by ./Importee1.g4 */
+
+grammar Importee3;
+
+Token1: 'c';
+Token2: '-';

--- a/tests/grammars/ImportActionsTokens.g4
+++ b/tests/grammars/ImportActionsTokens.g4
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Renata Hodovan, Akos Kiss.
+ *
+ * Licensed under the BSD 3-Clause License
+ * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+ * This file may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+
+/*
+ * This test checks whether the grammar import mechanism works for named
+ * actions and tokens specifications.
+ */
+
+// TEST-PROCESS: {grammar}.g4 -o {tmpdir} --lib import
+// TEST-GENERATE: {grammar}Generator.{grammar}Generator -r start -j 1 -o {tmpdir}/{grammar}%d.txt
+// TEST-ANTLR: {grammar}.g4 -o {tmpdir} -lib import
+
+grammar ImportActionsTokens;
+
+import ImportedActionsTokens;
+
+@header {
+QUESTION = 'What do you get when you multiply six by nine?'
+}
+
+@members {
+def _question(self):
+    return QUESTION
+}
+
+tokens { Question, Space }
+
+start:
+    Question {current.last_child.src = self._question()}
+    Space {current.last_child.src = ' '}
+    Answer {current.last_child.src = self._answer()}
+    {assert str(current) == 'What do you get when you multiply six by nine? 42'};

--- a/tests/grammars/Importer.g4
+++ b/tests/grammars/Importer.g4
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 Renata Hodovan, Akos Kiss.
+ * Copyright (c) 2017-2025 Renata Hodovan, Akos Kiss.
  *
  * Licensed under the BSD 3-Clause License
  * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -9,8 +9,15 @@
 
 /*
  * This test checks whether the grammar import mechanism (using rules of a
- * different grammar) works, even from a different directory (via the `--lib`
- * CLI option).
+ * different grammar) works, i.e.,
+ * - a grammar can import multiple other grammars,
+ * - even an imported grammar can import further grammar(s),
+ * - if more than one imported grammar defines a rule, the first version found
+ *   is used,
+ * - both lexical and parser imported rules can be overridden.
+ *
+ * This test also checks that imports work even from a different directory (via
+ * the `--lib` CLI option).
  */
 
 // TEST-PROCESS: {grammar}.g4 -o {tmpdir} --lib import
@@ -20,8 +27,12 @@
 
 grammar Importer;
 
-import Importee;
+import Importee1, Importee2;
+// inherits Importee1.Token1 which hides Importee2.Token1
+// inherits Importee3.Token2 which hides Importee2.Token2
+// inherits Importee1.Token3 which hides Importee2.Token3
+// inherits Importee2.Token4
 
-start
-  : importee
-  ;
+start: Token1 Token2 Token3 Token4 Token5;  // overrides Importee1.start
+
+Token5: '\n';  // adds Token5

--- a/tests/grammars/import/ImportedActionsTokens.g4
+++ b/tests/grammars/import/ImportedActionsTokens.g4
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Renata Hodovan, Akos Kiss.
+ *
+ * Licensed under the BSD 3-Clause License
+ * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+ * This file may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+
+/* This grammar is used by ../ImportActionsTokens.g4 */
+
+grammar ImportedActionsTokens;
+
+@header {
+ANSWER = '42'
+}
+
+@members {
+def _answer(self):
+    return ANSWER
+}
+
+tokens { Answer, Space }

--- a/tests/grammars/import/Importee1.g4
+++ b/tests/grammars/import/Importee1.g4
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Renata Hodovan, Akos Kiss.
+ * Copyright (c) 2025 Renata Hodovan, Akos Kiss.
  *
  * Licensed under the BSD 3-Clause License
  * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -9,8 +9,12 @@
 
 /* This grammar is used by ../Importer.g4 */
 
-grammar Importee;
+grammar Importee1;
 
-importee
-  : 'pass'
-  ;
+import Importee3;
+
+start: Token1 Token2 Token3;
+
+Token1: 'a';  // overrides Importee3.Token1
+// inherits Importee3.Token2
+Token3: 'x';  // adds Token3

--- a/tests/grammars/import/Importee2.g4
+++ b/tests/grammars/import/Importee2.g4
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renata Hodovan, Akos Kiss.
+ *
+ * Licensed under the BSD 3-Clause License
+ * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+ * This file may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+
+/* This grammar is used by ../Importer.g4 */
+
+grammar Importee2;
+
+Token1: 'b';
+Token2: '+';
+Token3: 'y';
+Token4: ';';

--- a/tests/grammars/import/Importee3.g4
+++ b/tests/grammars/import/Importee3.g4
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Renata Hodovan, Akos Kiss.
+ *
+ * Licensed under the BSD 3-Clause License
+ * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+ * This file may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+
+/* This grammar is used by ./Importee1.g4 */
+
+grammar Importee3;
+
+Token1: 'c';
+Token2: '-';


### PR DESCRIPTION
Ensure that imported grammars do not override rules of the main grammar. Also copy lexer mode rules, named actions, and tokens specifications from imported grammars into the importing grammar.

Additionally, fix the C++ codegen template to generate correct code for tokens with no associated lexical rule.