### PR TITLE
Refactor Population and Individual implementations

### DIFF
--- a/grammarinator-cxx/libgrammarinator/include/grammarinator/runtime/Population.hpp
+++ b/grammarinator-cxx/libgrammarinator/include/grammarinator/runtime/Population.hpp
@@ -230,14 +230,15 @@ private:
 };
 
 class Individual {
-public:
-  std::string name;
-
 private:
   Annotations* annot_{};
+  bool delete_root_;
+
+protected:
+  Rule* root_;
 
 public:
-  explicit Individual(const std::string& name) : name(name) { }
+  explicit Individual(Rule* root = nullptr, bool delete_root = true) : root_(root), delete_root_(delete_root) { }
   Individual(const Individual& other) = delete;
   Individual& operator=(const Individual& other) = delete;
   Individual(Individual&& other) = delete;
@@ -245,9 +246,15 @@ public:
 
   virtual ~Individual() {
     delete annot_;
+
+    if (delete_root_) {
+      delete root_;
+    }
   }
 
-  virtual Rule* root() = 0;
+  virtual Rule* root() {
+    return root_;
+  };
 
   Annotations* annotations() {
     if (!annot_) {

--- a/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/FilePopulation.hpp
+++ b/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/FilePopulation.hpp
@@ -27,20 +27,17 @@ class FilePopulation;
 class FileIndividual : public runtime::Individual {
 private:
   FilePopulation* population_;
-  runtime::Rule* root_{};
+  std::string name_;
 
 public:
   FileIndividual(FilePopulation* population, const std::string& name)
-      : Individual(name), population_(population) { }
+      : Individual(), population_(population), name_(name) { }
 
   FileIndividual(const FileIndividual& other) = delete;
   FileIndividual& operator=(const FileIndividual& other) = delete;
   FileIndividual(FileIndividual&& other) = delete;
   FileIndividual& operator=(FileIndividual&& other) = delete;
-
-  ~FileIndividual() override {
-    delete root_;
-  }
+  ~FileIndividual() override = default;
 
   runtime::Rule* root() override;
 };
@@ -131,7 +128,7 @@ private:
 
 inline runtime::Rule* FileIndividual::root() {
   if (!root_) {
-    root_ = population_->load(name);
+    root_ = population_->load(name_);
   }
   return root_;
 }

--- a/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/LibFuzzerTool.hpp
+++ b/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/LibFuzzerTool.hpp
@@ -26,21 +26,6 @@ extern "C" size_t LLVMFuzzerMutate(uint8_t* Data, size_t Size, size_t MaxSize);
 namespace grammarinator {
 namespace tool {
 
-class LibFuzzerIndividual : public runtime::Individual {
-private:
-  runtime::Rule* root_;
-
-public:
-  explicit LibFuzzerIndividual(runtime::Rule* root) : runtime::Individual(""), root_(root) { }
-  LibFuzzerIndividual(const LibFuzzerIndividual& other) = delete;
-  LibFuzzerIndividual& operator=(const LibFuzzerIndividual& other) = delete;
-  LibFuzzerIndividual(LibFuzzerIndividual&& other) = delete;
-  LibFuzzerIndividual& operator=(LibFuzzerIndividual&& other) = delete;
-  ~LibFuzzerIndividual() override = default;  // NOTE: do NOT delete root!
-
-  runtime::Rule* root() override { return root_; }
-};
-
 class LastMutationCache {
 private:
   std::vector<uint8_t> data_;
@@ -125,7 +110,7 @@ public:
 
     // util::poutf("MUTATE({})\n---------------\n{}", size, this->serializer(root));
 
-    LibFuzzerIndividual individual(root);
+    runtime::Individual individual(root, false);
     auto mutated_root = this->mutate(&individual);
     size_t outsize = this->codec.encode(mutated_root, data, maxsize);
     if (outsize == 0) {
@@ -159,7 +144,7 @@ public:
       recipient_root = decode(data1, size1);
     auto donor_root = decode(data2, size2);
 
-    LibFuzzerIndividual recipient_individual(recipient_root), donor_individual(donor_root);
+    runtime::Individual recipient_individual(recipient_root, false), donor_individual(donor_root, false);
     auto cross_over_root = this->recombine(&recipient_individual, &donor_individual);
     size_t outsize = this->codec.encode(cross_over_root, out, maxoutsize);
     if (outsize == 0) {

--- a/grammarinator/runtime/population.py
+++ b/grammarinator/runtime/population.py
@@ -68,11 +68,11 @@ class Individual:
     Abstract base class of population individuals.
     """
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, root: Optional[Rule] = None) -> None:
         """
-        :param name: Name or identifier of the individual.
+        :param root: Root of the tree of the individual.
         """
-        self.name: str = name  #: Identifier of the individual.
+        self._root = root
         self._annot: Optional[Annotations] = None
 
     @property
@@ -82,7 +82,8 @@ class Individual:
 
         :return: Root of the tree.
         """
-        raise NotImplementedError()
+        assert self._root is not None
+        return self._root
 
     @property
     def annotations(self) -> Annotations:

--- a/grammarinator/tool/file_population.py
+++ b/grammarinator/tool/file_population.py
@@ -100,9 +100,9 @@ class FileIndividual(Individual):
         :param population: The population this individual belongs to.
         :param name: Path to the encoded tree file.
         """
-        super().__init__(name)
+        super().__init__()
         self._population: FilePopulation = population
-        self._root: Optional[Rule] = None
+        self._name: str = name
 
     @property
     def root(self) -> Rule:
@@ -113,5 +113,5 @@ class FileIndividual(Individual):
         :return: The root of the tree.
         """
         if not self._root:
-            self._root, self._annot = self._population._load(self.name)
+            self._root, self._annot = self._population._load(self._name)
         return self._root


### PR DESCRIPTION
The minimal requirements for an Individual is to provide or load the root of its represented tree and be able to compute Annotations. All other behavior should be implemented in subclasses as needed.

From now, the base Individual no longer expects a `name` parameter (used only by FileIndividual), and instead allows directly providing and returning the tree root. This makes the LibFuzzerIndividual class unnecessary, since it required only this core functionality.