### PR TITLE
Ensure that the root of the tree is never selected for replacement or…

### DIFF
--- a/grammarinator-cxx/libgrammarinator/include/grammarinator/runtime/Population.hpp
+++ b/grammarinator-cxx/libgrammarinator/include/grammarinator/runtime/Population.hpp
@@ -158,6 +158,7 @@ public:
 private:
   void collect_rules(Rule* current) {
     if ((current->type == Rule::UnlexerRuleType || current->type == Rule::UnparserRuleType) &&
+        current != root_ &&
         !current->name.empty() && current->name != "<INVALID>" && current->name != "<ROOT>" &&
         (current->type != Rule::UnlexerRuleType || !static_cast<UnlexerRule*>(current)->immutable)) {
         rules_by_name_[NodeKey(current->name)].push_back(current);

--- a/grammarinator/runtime/population.py
+++ b/grammarinator/runtime/population.py
@@ -115,7 +115,7 @@ class Annotations:
             if isinstance(current, (UnlexerRule, UnparserRule)):
                 if current.name and current.name != '<INVALID>':
                     current_rule_name = (current.name,)
-                    if not isinstance(current, UnlexerRule) or not current.immutable:
+                    if current != root and (not isinstance(current, UnlexerRule) or not current.immutable):
                         if current_rule_name not in self.rules_by_name:
                             self.rules_by_name[current_rule_name] = []
                         self.rules_by_name[current_rule_name].append(current)

--- a/tests/grammars-cxx/LifeCycle.g4
+++ b/tests/grammars-cxx/LifeCycle.g4
@@ -27,7 +27,6 @@
 // TEST-PROCESS-CXX: {grammar}.g4 -o {tmpdir}
 // TEST-BUILD-CXX: --generator={grammar}Generator --serializer=grammarinator::runtime::SimpleSpaceSerializer --includedir={tmpdir} --builddir={tmpdir}/build
 // TEST-GENERATE-CXX: {tmpdir}/build/bin/grammarinator-generate-{grammar_lower} -r start -n 3 -o {tmpdir}/{grammar}A%d.txt
-// TEST-SKIP: SIGSEGV when working with population
 // TEST-PARSE: -g {grammar}.g4 -j 1 -r start --hidden WS -o {tmpdir}/population/j/ --tree-format json {tmpdir}/LifeCycleA0.txt {tmpdir}/LifeCycleA1.txt {tmpdir}/LifeCycleA2.txt
 // TEST-GENERATE-CXX: {tmpdir}/build/bin/grammarinator-generate-{grammar_lower} -r start -n 3 --population {tmpdir}/population/j/ --tree-format json -o {tmpdir}/{grammar}JB%d.txt --keep-trees --no-generate --no-recombine
 // TEST-GENERATE-CXX: {tmpdir}/build/bin/grammarinator-generate-{grammar_lower} -r start -n 3 --population {tmpdir}/population/j/ --tree-format json -o {tmpdir}/{grammar}JC%d.txt --keep-trees --no-generate --no-mutate


### PR DESCRIPTION
… delete

The patch filters out the root from the collected rules list, which provides the list of possible inputs for certain creators. This fixes the SEGV in LifeCycle test, which is unskipped now.