### PR TITLE
Bump dependencies to latest versions

### DIFF
--- a/grammarinator-cxx/conanfile.txt
+++ b/grammarinator-cxx/conanfile.txt
@@ -1,7 +1,7 @@
 [requires]
-cxxopts/3.2.0
-nlohmann_json/3.11.3
-flatbuffers/24.12.23
+cxxopts/3.3.1
+nlohmann_json/3.12.0
+flatbuffers/25.9.23
 xxhash/0.8.3
 
 [generators]

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     antlr4-python3-runtime==4.13.2
     autopep8
     enlighten
-    flatbuffers==24.12.23
+    flatbuffers==25.9.23
     inators
     jinja2
     regex


### PR DESCRIPTION
- flatbuffers to 25.9.23 (both in Python and C++)
- cxxopts to 3.3.1 (in C++)
- nlohmann_json to 3.12.0 (in C++)