### PR TITLE
Support per-rule options, and add virtual option to C++ code generation

### DIFF
--- a/docs/guide/grammar_overview.rst
+++ b/docs/guide/grammar_overview.rst
@@ -73,6 +73,12 @@ are as follows:
      - ``any_ascii_letter``: generates any ASCII letter
      - ``any_ascii_char``: generates any ASCII character
      - ``any_unicode_char``: generates any Unicode character
+  3) ``virtual``: This option defines whether methods of the created generator
+     should use dynamic dispatch and thus be overridable in derived classes.
+     Possible values are ``true`` or ``false``. Used by C++ code generation,
+     ignored in Python. (This option can also be specified on a per-rule basis
+     usig the rule option syntax, in which case the option defined at rule level
+     takes precedence.)
 
 **Imports** allow for the inclusion of external grammars into the importing
 grammar. This means that the rules defined in the imported grammar will be

--- a/grammarinator/tool/resources/codegen/GeneratorTemplate.hpp.jinja
+++ b/grammarinator/tool/resources/codegen/GeneratorTemplate.hpp.jinja
@@ -167,7 +167,7 @@ public:
     {% endif %}
 
     {% for rule in graph.rules %}
-    Rule* {{ rule.id | join('_') }}({% for t, k, v in rule.args %}{{ t }} {{ k }}{% if v %}={{ resolveVarRefs(v) }}{% endif %}, {% endfor %}Rule *parent = nullptr) {
+    {% if rule.options.get('virtual', graph.options.get('virtual', 'false')) == 'true' %}virtual {% endif %}Rule* {{ rule.id | join('_') }}({% for t, k, v in rule.args %}{{ t }} {{ k }}{% if v %}={{ resolveVarRefs(v) }}{% endif %}, {% endfor %}Rule *parent = nullptr) {
         {% if rule.labels or rule.args or rule.locals or rule.returns %}
         struct {
             {% for t, k, _ in rule.args %}

--- a/tests/grammars-cxx/Custom.g4
+++ b/tests/grammars-cxx/Custom.g4
@@ -25,7 +25,6 @@
 // TEST-PROCESS-CXX: {grammar}.g4 -o {tmpdir}
 // TEST-BUILD-CXX: --generator={grammar}Generator --includedir={tmpdir} --builddir={tmpdir}/build/G
 // TEST-GENERATE-CXX: {tmpdir}/build/G/bin/grammarinator-generate-{grammar_lower} -r start -n 5 -o {tmpdir}/{grammar}G%d.txt
-// TEST-SKIP: method of subclass will not be called since the base method is not virtual
 // TEST-BUILD-CXX: --generator={grammar}SubclassGenerator --includedir={tmpdir} --builddir={tmpdir}/build/S
 // TEST-GENERATE-CXX: {tmpdir}/build/S/bin/grammarinator-generate-{grammar_lower}subclass -r start -n 5 -o {tmpdir}/{grammar}S%d.txt
 
@@ -61,7 +60,7 @@ tag
   : '<' remember=tagname '>' (cnt+=CONTENT)+ {assert(!$cnt.empty());} '</' tagname {static_cast<UnparserRule*>(current)->last_child()->replace($remember->clone());} '>'
   ;
 
-tagname
+tagname options {virtual=true;}
   : ID
   ;
 

--- a/tests/grammars-cxx/CustomSubclassGenerator.hpp
+++ b/tests/grammars-cxx/CustomSubclassGenerator.hpp
@@ -14,14 +14,18 @@
 
 
 class CustomSubclassGenerator : public CustomGenerator {
+private:
+  int cnt{0};
+
 public:
   explicit CustomSubclassGenerator(Model* model=new DefaultModel(),
                                    const std::vector<Listener*>& listeners={},
                                    const RuleSize& limit=RuleSize::max())
       : CustomGenerator(model, listeners, limit) {}
 
-  // FIXME: this will not be called at all since the base method is not virtual
-  Rule* tagname(Rule *parent = nullptr) {
+  Rule* tagname(Rule *parent = nullptr) override {
+    cnt++;
+
     UnparserRuleContext rule(this, "tagname", parent);
     UnparserRule* current = static_cast<UnparserRule*>(rule.current());
     current->add_child(new UnlexerRule("ID", "customtag"));
@@ -29,6 +33,7 @@ public:
   }
 
   std::string _custom_lexer_content() override {
+    assert(cnt > 0);
     return "custom content";
   }
 };

--- a/tests/grammars/CustomSubclassGenerator.py
+++ b/tests/grammars/CustomSubclassGenerator.py
@@ -14,11 +14,16 @@ from CustomGenerator import CustomGenerator
 
 class CustomSubclassGenerator(CustomGenerator):
 
+    cnt: int = 0
+
     def tagname(self, parent=None):
+        self.cnt += 1
+
         with UnparserRuleContext(self, 'tagname', parent) as rule:
             current = rule.current
             current += UnlexerRule(name='ID', src='customtag')
             return current
 
     def _custom_lexer_content(self):
+        assert self.cnt > 0
         return 'custom content'


### PR DESCRIPTION
The format of g4 files has been supporting per-rule options as `RuleName options { optionName=value; } : ...;` for a long time, and ANTLRv4 has been supporting at least one such option (`caseInsensitive`) since 4.10.

This commit adds support for per-rule options in general (i.e., such options are parsed and stored in internal data structures), and defines the `virtual` option (both at grammar and rule levels) to control the C++ code generation, i.e., whether methods corresponding to grammar rules should be virtual or not.

As a result, this change enables the Custom.g4 test case among the C++ grammar tests. (The Python counterpart is adapted accordingly.)