### PR TITLE
Generalize replace and swap nodes mutators

### DIFF
--- a/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/Tool.hpp
+++ b/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/Tool.hpp
@@ -265,17 +265,8 @@ public:
     auto donor_annot = ensured_donor->annotations();
     const auto& donor_node_info = donor_annot->node_info();
 
-    // NOTE: merges clear the data structures of recipient_lookup
-    std::map<runtime::Annotations::NodeKey, std::vector<runtime::Rule*>> recipient_lookup;
-    recipient_lookup.merge(recipient_annot->rules_by_name());
-    recipient_lookup.merge(recipient_annot->quants_by_name());
-    recipient_lookup.merge(recipient_annot->alts_by_name());
-
-    // NOTE: merges clear the data structures of donor_lookup
-    std::map<runtime::Annotations::NodeKey, std::vector<runtime::Rule*>> donor_lookup;
-    donor_lookup.merge(donor_annot->rules_by_name());
-    donor_lookup.merge(donor_annot->quants_by_name());
-    donor_lookup.merge(donor_annot->alts_by_name());
+    std::map<runtime::Annotations::NodeKey, std::vector<runtime::Rule*>> recipient_lookup = recipient_annot->nodes_by_name();
+    std::map<runtime::Annotations::NodeKey, std::vector<runtime::Rule*>> donor_lookup = donor_annot->nodes_by_name();
 
     std::vector<runtime::Annotations::NodeKey> common_types;
     for (const auto& [recipient_key, value] : recipient_lookup) {
@@ -544,15 +535,7 @@ public:
     auto annot = individual->annotations();
 
     std::vector<std::vector<runtime::Rule*>*> options;
-    for (auto& [key, nodes] : annot->rules_by_name()) {
-      if (nodes.size() > 1)
-        options.push_back(&nodes);
-    }
-    for (auto& [key, nodes] : annot->quants_by_name()) {
-      if (nodes.size() > 1)
-        options.push_back(&nodes);
-    }
-    for (auto& [key, nodes] : annot->alts_by_name()) {
+    for (auto& [key, nodes] : annot->nodes_by_name()) {
       if (nodes.size() > 1)
         options.push_back(&nodes);
     }

--- a/grammarinator/tool/generator.py
+++ b/grammarinator/tool/generator.py
@@ -465,13 +465,8 @@ class GeneratorTool:
         recipient_root, recipient_annot = recipient_individual.root, recipient_individual.annotations
         donor_annot = donor_individual.annotations
 
-        recipient_lookup: dict[str, Sequence[Rule]] = dict(recipient_annot.rules_by_name)
-        recipient_lookup.update(recipient_annot.quants_by_name)
-        recipient_lookup.update(recipient_annot.alts_by_name)
-
-        donor_lookup: dict[str, Sequence[Rule]] = dict(donor_annot.rules_by_name)
-        donor_lookup.update(donor_annot.quants_by_name)
-        donor_lookup.update(donor_annot.alts_by_name)
+        recipient_lookup: dict[str, Sequence[Rule]] = dict(recipient_annot.nodes_by_name)
+        donor_lookup: dict[str, Sequence[Rule]] = dict(donor_annot.nodes_by_name)
         common_types = sorted(set(recipient_lookup.keys()) & set(donor_lookup.keys()))
 
         recipient_options = [(rule_name, node) for rule_name in common_types for node in recipient_lookup[rule_name] if node.parent]
@@ -650,10 +645,7 @@ class GeneratorTool:
         individual = self._ensure_individual(individual)
         root, annot = individual.root, individual.annotations
 
-        options: dict[str, Sequence[Rule]] = dict(annot.rules_by_name)
-        options.update(annot.quants_by_name)
-        options.update(annot.alts_by_name)
-
+        options: dict[str, Sequence[Rule]] = dict(annot.nodes_by_name)
         for _, nodes in random.sample(list(options.items()), k=len(options)):
             # Skip node types without two instances.
             if len(nodes) < 2:


### PR DESCRIPTION
Instead of restricting the application of the aforementioned mutators to only alternatives, quantifiers and rules, from now they can be applied on quantified nodes as well. Furthermore, the patch removes some superfluous checks from related functions.