### PR TITLE
Always generate virtual methods for `tokens` in C++

### DIFF
--- a/grammarinator/tool/resources/codegen/GeneratorTemplate.hpp.jinja
+++ b/grammarinator/tool/resources/codegen/GeneratorTemplate.hpp.jinja
@@ -156,7 +156,7 @@ public:
     explicit {{ graph.name }}(Model* model=new DefaultModel(), const std::vector<Listener*>& listeners={}, const RuleSize& limit=RuleSize::max()) : {{ graph.superclass }}(model, listeners, limit) {}
 
     {% for rule in graph.imag_rules %}
-    Rule* {{ rule.id | join('_') }}(Rule *parent = nullptr) {
+    virtual Rule* {{ rule.id | join('_') }}(Rule *parent = nullptr) {
         UnlexerRuleContext rule(this, "{{ rule.id | join('_') }}", parent);
         return rule.current();
     }

--- a/tests/grammars-cxx/ImagToken.g4
+++ b/tests/grammars-cxx/ImagToken.g4
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2017-2025 Renata Hodovan, Akos Kiss.
+ *
+ * Licensed under the BSD 3-Clause License
+ * <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+ * This file may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+
+/*
+ * This test checks whether imaginary tokens are handled correctly.
+ */
+
+// TEST-PROCESS-CXX: {grammar}.g4 -o {tmpdir}
+// TEST-BUILD-CXX: --generator={grammar}SubclassGenerator --includedir={tmpdir} --builddir={tmpdir}/build
+// TEST-GENERATE-CXX: {tmpdir}/build/bin/grammarinator-generate-{grammar_lower}subclass -r start -o {tmpdir}/{grammar}%d.txt
+// TEST-ANTLR: {grammar}.g4 -o {tmpdir}
+
+grammar ImagToken;
+
+@header {
+#include <cassert>
+}
+
+tokens { IMAG, REDEFINED }
+
+start
+  : IMAG {assert(static_cast<UnlexerRule*>(static_cast<UnparserRule*>(current)->last_child())->name == "IMAG" && static_cast<UnlexerRule*>(static_cast<UnparserRule*>(current)->last_child())->src == "");}
+    REDEFINED {assert(static_cast<UnlexerRule*>(static_cast<UnparserRule*>(current)->last_child())->src == "redefined");}
+  ;

--- a/tests/grammars-cxx/ImagTokenSubclassGenerator.hpp
+++ b/tests/grammars-cxx/ImagTokenSubclassGenerator.hpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 Renata Hodovan, Akos Kiss.
+//
+// Licensed under the BSD 3-Clause License
+// <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
+// This file may not be copied, modified, or distributed except
+// according to those terms.
+
+// This subclassed generator is used by ImagToken.g4
+
+#ifndef IMAGTOKENSUBCLASSGENERATOR_HPP
+#define IMAGTOKENSUBCLASSGENERATOR_HPP
+
+#include "ImagTokenGenerator.hpp"
+
+
+class ImagTokenSubclassGenerator : public ImagTokenGenerator {
+public:
+  explicit ImagTokenSubclassGenerator(Model* model=new DefaultModel(),
+                                      const std::vector<Listener*>& listeners={},
+                                      const RuleSize& limit=RuleSize::max())
+      : ImagTokenGenerator(model, listeners, limit) {}
+
+  Rule* REDEFINED(Rule* parent = nullptr) override {
+    UnlexerRuleContext rule(this, "REDEFINED", parent);
+    UnlexerRule* current = static_cast<UnlexerRule*>(rule.current());
+    current->src += "redefined";
+    return current;
+  }
+};
+
+#endif // IMAGTOKENSUBCLASSGENERATOR_HPP


### PR DESCRIPTION
Tokens without and associated lexer rule are useless if they cannot be overridden. Therefore, all (almost empty) methods that are generated for such tokens are generated as `virtual` in C++ code generation.

As a result, this change enables the ImagToken.g4 test case among the C++ grammar tests.