### PR TITLE
Simplify grammar test case IDs

### DIFF
--- a/tests/run_grammars.py
+++ b/tests/run_grammars.py
@@ -47,6 +47,20 @@ def collect_grammar_commands(grammars_dir):
     return sorted(params)
 
 
+def create_grammar_ids(params):
+    """
+    Build a list of custom test IDs for grammar-commands test cases collected by
+    ``collect_grammar_commands``.
+
+    :param params: the result of the ``collect_grammar_commands`` function.
+    :return: the base names of the collected grammars files.
+
+    The result of the function can be used with pytest decorators as
+    ``@pytest.mark.parametrize('grammar, commands', gc := collect_grammar_commands('...'), ids=create_grammar_ids(gc))``.
+    """
+    return [os.path.basename(grammar) for grammar, _ in params]
+
+
 def run_subprocess(grammar, commandline, tmpdir):
     """
     Helper function for test command runners to execute a subprocess.

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2025 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -8,12 +8,16 @@
 import os
 import pytest
 
-from .run_grammars import collect_grammar_commands, run_grammar
+from .run_grammars import collect_grammar_commands, create_grammar_ids, run_grammar
 
 
 grammars_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'examples', 'grammars')
 
 
-@pytest.mark.parametrize('grammar, commands', collect_grammar_commands(grammars_dir))
+@pytest.mark.parametrize(
+    'grammar, commands',
+    grammar_commands := collect_grammar_commands(grammars_dir),  # pylint: disable=unused-variable
+    ids=create_grammar_ids(grammar_commands)  # pylint: disable=undefined-variable
+)
 def test_grammar(grammar, commands, tmpdir):
     run_grammar(grammar, commands, str(tmpdir))

--- a/tests/test_grammars.py
+++ b/tests/test_grammars.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2025 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -8,12 +8,16 @@
 import os
 import pytest
 
-from .run_grammars import collect_grammar_commands, run_grammar
+from .run_grammars import collect_grammar_commands, create_grammar_ids, run_grammar
 
 
 grammars_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'grammars')
 
 
-@pytest.mark.parametrize('grammar, commands', collect_grammar_commands(grammars_dir))
+@pytest.mark.parametrize(
+    'grammar, commands',
+    grammar_commands := collect_grammar_commands(grammars_dir),  # pylint: disable=unused-variable
+    ids=create_grammar_ids(grammar_commands)  # pylint: disable=undefined-variable
+)
 def test_grammar(grammar, commands, tmpdir):
     run_grammar(grammar, commands, str(tmpdir))

--- a/tests/test_grammars_cxx.py
+++ b/tests/test_grammars_cxx.py
@@ -8,13 +8,17 @@
 import os
 import pytest
 
-from .run_grammars import collect_grammar_commands, run_grammar
+from .run_grammars import collect_grammar_commands, create_grammar_ids, run_grammar
 
 
 grammars_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'grammars-cxx')
 
 
 @pytest.mark.cxxtest
-@pytest.mark.parametrize('grammar, commands', collect_grammar_commands(grammars_dir))
+@pytest.mark.parametrize(
+    'grammar, commands',
+    grammar_commands := collect_grammar_commands(grammars_dir),  # pylint: disable=unused-variable
+    ids=create_grammar_ids(grammar_commands)  # pylint: disable=undefined-variable
+)
 def test_grammar(grammar, commands, tmpdir):
     run_grammar(grammar, commands, str(tmpdir))


### PR DESCRIPTION
Generate custom (simpler) test case IDs for grammar tests. The custom test case ID is the base name of the tested grammar file. This makes the execution of selected test cases possible if necessary, typical during debugging. E.g.,
`tox -e cxx -- -k Hello.g4`.