### PR TITLE
Add include for `std::stringstream` in libgrlf

### DIFF
--- a/grammarinator-cxx/libgrlf/grlf.cpp
+++ b/grammarinator-cxx/libgrlf/grlf.cpp
@@ -14,6 +14,7 @@
 
 #include <cstring>
 #include <string>
+#include <sstream>
 #include <unordered_set>
 #include <vector>
 


### PR DESCRIPTION
Without `#include <sstream>`, build of libgrlf fails with `undefined template 'std::basic_stringstream<char>'` when using AppleClang 17.