### PR TITLE
Fix unsafe casting in JsonTreeCodec and add input validation

### DIFF
--- a/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/JsonTreeCodec.hpp
+++ b/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/JsonTreeCodec.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Renata Hodovan, Akos Kiss.
+// Copyright (c) 2025-2026 Renata Hodovan, Akos Kiss.
 //
 // Licensed under the BSD 3-Clause License
 // <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -8,6 +8,7 @@
 #ifndef GRAMMARINATOR_TOOL_JSONTREECODEC_HPP
 #define GRAMMARINATOR_TOOL_JSONTREECODEC_HPP
 
+#include "../util/log.hpp"
 #include "../util/print.hpp"
 #include "TreeCodec.hpp"
 
@@ -80,7 +81,7 @@ private:
         j["e"] = quant_node->stop != INT_MAX ? quant_node->stop : -1;
       }
       j["c"] = nlohmann::json::array();
-      for (const auto& child : static_cast<runtime::UnparserRule*>(node)->children) {
+      for (const auto& child : static_cast<runtime::ParentRule*>(node)->children) {
         j["c"].push_back(toJson(child));
       }
     }
@@ -88,6 +89,10 @@ private:
   }
 
   runtime::Rule* fromJson(const nlohmann::json& obj) const {
+    if (!obj.is_object() || !obj.contains("t")) {
+      GRAMMARINATOR_LOG_WARN("Invalid JSON tree node.");
+      return nullptr;
+    }
     if (obj["t"] == "l") {
       auto size = obj["z"].get<std::vector<int>>();
       return new runtime::UnlexerRule(obj["n"].get<std::string>(), obj["s"].get<std::string>(), runtime::RuleSize(size[0], size[1]), obj["i"]);
@@ -103,7 +108,11 @@ private:
       int end = obj["e"].get<int>();
       node = new runtime::UnparserRuleQuantifier(obj["i"].get<int>(), obj["b"].get<int>(), end != -1 ? end : INT_MAX);
     }
-    if (!obj["c"].empty()) {
+    if (!node) {
+      GRAMMARINATOR_LOG_WARN("Unknown JSON tree node type.");
+      return nullptr;
+    }
+    if (obj.contains("c") && !obj["c"].empty()) {
       for (const auto& child : obj["c"]) {
         node->add_child(fromJson(child));
       }

--- a/grammarinator/tool/tree_codec.py
+++ b/grammarinator/tool/tree_codec.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2023-2026 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,6 +6,7 @@
 # according to those terms.
 
 import json
+import logging
 import pickle
 import struct
 
@@ -16,6 +17,8 @@ import flatbuffers
 
 from ..runtime import Rule, RuleSize, UnlexerRule, UnparserRule, UnparserRuleAlternative, UnparserRuleQuantified, UnparserRuleQuantifier
 from .fbs import CreateFBRuleSize, FBRule, FBRuleAddAltIdx, FBRuleAddChildren, FBRuleAddIdx, FBRuleAddImmutable, FBRuleAddName, FBRuleAddSize, FBRuleAddSrc, FBRuleAddStart, FBRuleAddStop, FBRuleAddType, FBRuleEnd, FBRuleStart, FBRuleStartChildrenVector, FBRuleType
+
+logger = logging.getLogger(__name__)
 
 
 class TreeCodec:
@@ -154,6 +157,10 @@ class JsonTreeCodec(TreeCodec):
         bytes using the specified encoding.
         """
         def _dict_to_rule(dct):
+            if not isinstance(dct, dict) or 't' not in dct:
+                logger.warning('Invalid JSON tree node.')
+                return None
+
             if dct['t'] == 'l':
                 return UnlexerRule(name=dct['n'], src=dct['s'], size=RuleSize(depth=dct['z'][0], tokens=dct['z'][1]), immutable=dct['i'])
             if dct['t'] == 'p':
@@ -164,11 +171,14 @@ class JsonTreeCodec(TreeCodec):
                 return UnparserRuleQuantified(children=dct['c'])
             if dct['t'] == 'q':
                 return UnparserRuleQuantifier(idx=dct['i'], start=dct['b'], stop=dct['e'] if dct['e'] != -1 else inf, children=dct['c'])
-            raise json.JSONDecodeError
+
+            logger.warning('Unknown JSON tree node type.')
+            return None
 
         try:
             return json.loads(data.decode(encoding=self._encoding, errors=self._encoding_errors), object_hook=_dict_to_rule)
         except json.JSONDecodeError:
+            logger.warning('Invalid JSON input.')
             return None
 
 


### PR DESCRIPTION
Fix incorrect casting in JsonTreeCodec.hpp where non-UnparserRule nodes were cast to UnparserRule* to access children. Replace with ParentRule* and add validation for invalid or unknown JSON nodes. Adapt error handling in Python.