### PR TITLE
Improve the handling of missing individuals

### DIFF
--- a/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/Tool.hpp
+++ b/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/Tool.hpp
@@ -133,7 +133,9 @@ protected:
 
     while (!creators.empty()) {
       auto creatorit = select_creator(creators, individual1, individual2);
-      GRAMMARINATOR_LOG_TRACE("Original test: '{}'", serializer(individual1->root()));
+      if (individual1) {
+        GRAMMARINATOR_LOG_TRACE("Original test: '{}'", serializer(individual1->root()));
+      }
       last_mutator = creatorit->first;
       root = creatorit->second(individual1, individual2);
       if (root) {
@@ -142,7 +144,8 @@ protected:
       creators.erase(creatorit->first);
     }
     if (!root) {
-      root = individual1->root();
+      GRAMMARINATOR_LOG_WARN("No test creator could produce a tree.");
+      return nullptr;
     }
     for (const auto& transformer : transformers) {
       root = transformer(root);

--- a/grammarinator/tool/generator.py
+++ b/grammarinator/tool/generator.py
@@ -279,7 +279,7 @@ class GeneratorTool:
             if self._memoize_test(test):
                 break
             logger.debug("test case #%d, attempt %d/%d: already generated among the last %d unique test cases", index, attempt, self._unique_attempts, len(self._memo))
-        if self._dry_run:
+        if self._dry_run or not root:
             return None
 
         test_fn = self._out_format % index if '%d' in self._out_format else self._out_format
@@ -317,7 +317,7 @@ class GeneratorTool:
         # NOTE: May be overridden.
         return random.choice(creators)
 
-    def _create_tree(self, creators: list[Callable[[Individual | None, Individual | None], Rule | None]], individual1: Individual | None, individual2: Individual | None) -> Rule:
+    def _create_tree(self, creators: list[Callable[[Individual | None, Individual | None], Rule | None]], individual1: Individual | None, individual2: Individual | None) -> Rule | None:
         # Note: creators is potentially modified (creators that return None are removed). Always ensure it is a copy when calling this method.
         while creators:
             creator = self._select_creator(creators, individual1, individual2)
@@ -326,14 +326,14 @@ class GeneratorTool:
                 break
             creators.remove(creator)
         else:
-            assert individual1 is not None
-            root = individual1.root
+            logger.warning("No test creators could produce a tree")
+            return None
 
         for transformer in self._transformers:
             root = transformer(root)
         return root
 
-    def create(self) -> Rule:
+    def create(self) -> Rule | None:
         """
         Create a new tree with a randomly selected generator method from the
         available options (see :meth:`generate`, :meth:`mutate`, and
@@ -350,7 +350,7 @@ class GeneratorTool:
             creators.extend(self._recombiners)
         return self._create_tree(creators, individual1, individual2)
 
-    def mutate(self, individual: Individual | None = None) -> Rule:
+    def mutate(self, individual: Individual | None = None) -> Rule | None:
         """
         Dispatcher method for mutation operators: it picks one operator randomly
         and creates a new tree by applying the operator to an individual. The
@@ -372,7 +372,7 @@ class GeneratorTool:
         individual = self._ensure_individual(individual)
         return self._create_tree(self._mutators[:], individual, None)
 
-    def recombine(self, individual1: Individual | None = None, individual2: Individual | None = None) -> Rule:
+    def recombine(self, individual1: Individual | None = None, individual2: Individual | None = None) -> Rule | None:
         """
         Dispatcher method for recombination operators: it picks one operator
         randomly and creates a new tree by applying the operator to an


### PR DESCRIPTION
Prevent null dereference in Tool. Pure generation (without population) incorrectly accessed individual1->root() for trace logging and fallback logic. The patch also avoids fallbacking to the donor tree in case of failed mutation.