### PR TITLE
Fix encode return value and improve robustness of file/tree handling

### DIFF
--- a/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/FilePopulation.hpp
+++ b/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/FilePopulation.hpp
@@ -107,16 +107,22 @@ private:
   runtime::Rule* load(const std::string& fn) {
     std::ifstream infile(fn, std::ios::binary | std::ios::ate);
     if (!infile.is_open()) {
+      GRAMMARINATOR_LOG_WARN("Failed to open population file '{}'.", fn);
       return nullptr;
     }
 
     std::streamsize size = infile.tellg();
+    if (size < 0) {
+      GRAMMARINATOR_LOG_WARN("Failed to determine population file size '{}'.", fn);
+      return nullptr;
+    }
     infile.seekg(0, std::ios::beg);
     std::vector<uint8_t> buffer;
     buffer.resize(size);
 
     infile.unsetf(std::ios::skipws); // FIXME: Stop eating new lines in binary mode (necessary?)
-    if (!infile.read(reinterpret_cast<char*>(buffer.data()), size)) {
+    if (size > 0 && !infile.read(reinterpret_cast<char*>(buffer.data()), size)) {
+      GRAMMARINATOR_LOG_WARN("Failed to read population file '{}'.", fn);
       return nullptr;
     }
     infile.close();
@@ -133,6 +139,10 @@ inline runtime::Rule* FileIndividual::root() {
     return r;
   }
   r = population_->load(name_);
+  if (!r) {
+    GRAMMARINATOR_LOG_WARN("Failed to load individual from '{}'.", name_);
+    return nullptr;
+  }
   root_->add_child(r);
   return r;
 }

--- a/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/FlatBuffersTreeCodec.hpp
+++ b/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/FlatBuffersTreeCodec.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Renata Hodovan, Akos Kiss.
+// Copyright (c) 2025-2026 Renata Hodovan, Akos Kiss.
 //
 // Licensed under the BSD 3-Clause License
 // <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -134,6 +134,10 @@ private:
         parent_rule = new runtime::UnparserRuleQuantified();
       } else if (fbrule->type() == fbs::FBRuleType_UnparserRuleAlternativeType) {
         parent_rule = new runtime::UnparserRuleAlternative(fbrule->alt_idx(), fbrule->idx());
+      }
+      if (!parent_rule) {
+        GRAMMARINATOR_LOG_WARN("Unknown flatbuffer tree node type.");
+        return nullptr;
       }
 
       for (const auto* fbchild : *fbrule->children()) {

--- a/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/TreeCodec.hpp
+++ b/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/TreeCodec.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Renata Hodovan, Akos Kiss.
+// Copyright (c) 2025-2026 Renata Hodovan, Akos Kiss.
 //
 // Licensed under the BSD 3-Clause License
 // <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -30,7 +30,10 @@ public:
 
   virtual size_t encode(runtime::Rule* root, uint8_t* buffer, size_t maxsize) const {
     std::vector<uint8_t> vec = encode(root);
-    std::memcpy(buffer, vec.data(), vec.size() <= maxsize ? vec.size() : maxsize);
+    if (vec.size() > maxsize) {
+      return 0;
+    }
+    std::memcpy(buffer, vec.data(), vec.size());
     return vec.size();
   }
 

--- a/grammarinator/tool/file_population.py
+++ b/grammarinator/tool/file_population.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2023-2026 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -113,4 +113,6 @@ class FileIndividual(Individual):
         """
         if not self._root:
             self._root, self._annot = self._population._load(self._name)
+            if not self._root:
+                logger.warning("Failed to load individual from %r", self._name)
         return self._root


### PR DESCRIPTION
Correct default encode() in TreeCodec to return 0 on overflow instead of full size when truncation occurs, aligning with other codecs. Although TreeCodec::encode is currently unused, it is fixed for correctness.

Also improve handling of invalid files and malformed tree representations in FilePopulation and FlatBuffersTreeCodec.