### PR TITLE
Save AFL trees after queue processing

### DIFF
--- a/grammarinator-cxx/libgrafl/grafl.cpp
+++ b/grammarinator-cxx/libgrafl/grafl.cpp
@@ -227,19 +227,12 @@ unsigned char afl_custom_queue_get(void* data, const unsigned char* filename) {
 
   delete st->current_tree;
   st->current_tree = root;
-  //st->tool->save_tree(root);
-  return 1;
-}
 
-/**
- * This methods is called after adding a new test case to the queue. If the
- * contents of the file was changed, return True, False otherwise.
- */
-extern "C"
-u8 afl_custom_queue_new_entry(void *data, const unsigned char *filename_new_queue, const unsigned int *filename_orig_queue) {
-  auto* st = static_cast<grafl_state*>(data);
-  st->tool->save_tree(st->current_tree);
-  return 0;
+  // Save seed corpus entries to the tree pool when they are first processed.
+  if (st->afl->queue_cur && st->afl->queue_cur->depth == 1) {
+    st->tool->save_tree(root);
+  }
+  return 1;
 }
 
 /**


### PR DESCRIPTION
Populate the subtree pool from queue_get for seed corpus entries and from post_trim once AFL has finished processing a queue item.

Avoid saving newly discovered entries in queue_new_entry. Those entries are saved later from the decoded current tree, so the pool follows the processed corpus instead of transient discovery-time mutations.