### PR TITLE
Avoid leaking SubTreePopulation object in AFLTool

### DIFF
--- a/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/AFLTool.hpp
+++ b/grammarinator-cxx/libgrammarinator/include/grammarinator/tool/AFLTool.hpp
@@ -51,7 +51,7 @@ public:
   AFLTool& operator=(const AFLTool& other) = delete;
   AFLTool(AFLTool&& other) = delete;
   AFLTool& operator=(AFLTool&& other) = delete;
-  ~AFLTool() override = default;
+  ~AFLTool() override { delete this->population; }
 
   runtime::Rule* replace_from_pool(runtime::Individual* individual) {
     auto root = individual->root();


### PR DESCRIPTION
Explicitly delete the created population in the destructor of AFLTool.